### PR TITLE
modified documentation to not use DataConverter incorrectly

### DIFF
--- a/src/main/java/com/uber/cadence/worker/Worker.java
+++ b/src/main/java/com/uber/cadence/worker/Worker.java
@@ -23,7 +23,7 @@ import com.google.common.base.Preconditions;
 import com.uber.cadence.client.WorkflowClient;
 import com.uber.cadence.common.WorkflowExecutionHistory;
 import com.uber.cadence.context.ContextPropagator;
-import com.uber.cadence.converter.DataConverter;
+import com.uber.cadence.internal.worker.PollerOptions;
 import com.uber.cadence.internal.common.InternalUtils;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.replay.DeciderCache;
@@ -61,7 +61,7 @@ public final class Worker implements Suspendable {
    * @param client client to the Cadence Service endpoint.
    * @param taskList task list name worker uses to poll. It uses this name for both decision and
    *     activity task list polls.
-   * @param options Options (like {@link DataConverter} override) for configuring worker.
+   * @param options Options (like {@link PollerOptions} override) for configuring worker.
    */
   Worker(
       WorkflowClient client,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Documentation for Worker constructor

<!-- Tell your future self why have you made these changes -->
**Why?**
It incorrectly mentioned that things like DataConverter are being passed via options which is no longer the case since release v3.0.0.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
No actual code change done

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Nothing, worst case my documentation itself is incorrect.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
No

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
No
