### PR TITLE
Add unit tests for History Iterator in Replayer

### DIFF
--- a/src/main/java/com/uber/cadence/internal/replay/HistoryHelper.java
+++ b/src/main/java/com/uber/cadence/internal/replay/HistoryHelper.java
@@ -231,14 +231,8 @@ class HistoryHelper {
         }
         decisionEvents.add(events.next());
       }
-      DecisionEvents result =
-          new DecisionEvents(
-              newEvents,
-              decisionEvents,
-              replay,
-              replayCurrentTimeMilliseconds,
-              nextDecisionEventId);
-      return result;
+      return new DecisionEvents(
+          newEvents, decisionEvents, replay, replayCurrentTimeMilliseconds, nextDecisionEventId);
     }
   }
 

--- a/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
+++ b/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
@@ -685,6 +685,7 @@ class ReplayDecider implements Decider {
                   .setExpiration(decisionTaskRemainingTime)
                   .setInitialInterval(retryServiceOperationInitialInterval)
                   .setMaximumInterval(retryServiceOperationMaxInterval)
+                  .setBackoffCoefficient(2)
                   .build();
 
           GetWorkflowExecutionHistoryRequest request = new GetWorkflowExecutionHistoryRequest();

--- a/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
+++ b/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
@@ -685,8 +685,7 @@ class ReplayDecider implements Decider {
                   .setExpiration(decisionTaskRemainingTime)
                   .setInitialInterval(retryServiceOperationInitialInterval)
                   .setMaximumInterval(retryServiceOperationMaxInterval)
-                  .setBackoffCoefficient(2)
-                  .build();
+                  .validateBuildWithDefaults();
 
           GetWorkflowExecutionHistoryRequest request = new GetWorkflowExecutionHistoryRequest();
           request

--- a/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
+++ b/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
@@ -19,6 +19,7 @@ package com.uber.cadence.internal.replay;
 
 import static com.uber.cadence.worker.NonDeterministicWorkflowPolicy.FailWorkflow;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.uber.cadence.EventType;
 import com.uber.cadence.GetWorkflowExecutionHistoryRequest;
 import com.uber.cadence.GetWorkflowExecutionHistoryResponse;
@@ -634,6 +635,7 @@ class ReplayDecider implements Decider {
     private Iterator<HistoryEvent> current;
     private byte[] nextPageToken;
 
+    @VisibleForTesting
     DecisionTaskWithHistoryIteratorImpl(
         PollForDecisionTaskResponse task, Duration decisionTaskStartToCloseTimeout) {
       this.task = Objects.requireNonNull(task);

--- a/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
@@ -34,6 +34,7 @@ import com.uber.cadence.testing.TestEnvironmentOptions;
 import com.uber.cadence.workflow.*;
 import com.uber.cadence.workflow.Functions.Func;
 import com.uber.cadence.workflow.Functions.Func1;
+
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
@@ -52,976 +53,975 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
 import org.apache.thrift.TException;
 import org.apache.thrift.async.AsyncMethodCallback;
 
 public final class TestActivityEnvironmentInternal implements TestActivityEnvironment {
 
-  private final POJOActivityTaskHandler activityTaskHandler;
-  private final TestEnvironmentOptions testEnvironmentOptions;
-  private final AtomicInteger idSequencer = new AtomicInteger();
-  private ClassConsumerPair<Object> activityHeartbetListener;
-  private static final ScheduledExecutorService heartbeatExecutor =
-      Executors.newScheduledThreadPool(20);
-  private IWorkflowService workflowService;
+    private final POJOActivityTaskHandler activityTaskHandler;
+    private final TestEnvironmentOptions testEnvironmentOptions;
+    private final AtomicInteger idSequencer = new AtomicInteger();
+    private ClassConsumerPair<Object> activityHeartbetListener;
+    private static final ScheduledExecutorService heartbeatExecutor =
+            Executors.newScheduledThreadPool(20);
+    private IWorkflowService workflowService;
 
-  public TestActivityEnvironmentInternal(TestEnvironmentOptions options) {
-    if (options == null) {
-      this.testEnvironmentOptions = new TestEnvironmentOptions.Builder().build();
-    } else {
-      this.testEnvironmentOptions = options;
-    }
-    activityTaskHandler =
-        new POJOActivityTaskHandler(
-            new WorkflowServiceWrapper(workflowService),
-            testEnvironmentOptions.getWorkflowClientOptions().getDomain(),
-            testEnvironmentOptions.getDataConverter(),
-            heartbeatExecutor);
-  }
-
-  /**
-   * Register activity implementation objects with a worker. Overwrites previously registered
-   * objects. As activities are reentrant and stateless only one instance per activity type is
-   * registered.
-   *
-   * <p>Implementations that share a worker must implement different interfaces as an activity type
-   * is identified by the activity interface, not by the implementation.
-   *
-   * <p>
-   */
-  @Override
-  public void registerActivitiesImplementations(Object... activityImplementations) {
-    activityTaskHandler.setActivitiesImplementation(activityImplementations);
-  }
-
-  /**
-   * Creates client stub to activities that implement given interface.
-   *
-   * @param activityInterface interface type implemented by activities
-   */
-  @Override
-  public <T> T newActivityStub(Class<T> activityInterface) {
-    ActivityOptions options =
-        new ActivityOptions.Builder().setScheduleToCloseTimeout(Duration.ofDays(1)).build();
-    InvocationHandler invocationHandler =
-        ActivityInvocationHandler.newInstance(
-            options, new TestActivityExecutor(workflowService, null));
-    invocationHandler = new DeterministicRunnerWrapper(invocationHandler);
-    return ActivityInvocationHandlerBase.newProxy(activityInterface, invocationHandler);
-  }
-
-  @Override
-  public <T> void setActivityHeartbeatListener(Class<T> detailsClass, Consumer<T> listener) {
-    setActivityHeartbeatListener(detailsClass, detailsClass, listener);
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> void setActivityHeartbeatListener(
-      Class<T> detailsClass, Type detailsType, Consumer<T> listener) {
-    activityHeartbetListener = new ClassConsumerPair(detailsClass, detailsType, listener);
-  }
-
-  @Override
-  public void setWorkflowService(IWorkflowService workflowService) {
-    IWorkflowService service = new WorkflowServiceWrapper(workflowService);
-    this.workflowService = service;
-    this.activityTaskHandler.setWorkflowService(service);
-  }
-
-  private class TestActivityExecutor extends WorkflowInterceptorBase {
-
-    @SuppressWarnings("UnusedVariable")
-    private final IWorkflowService workflowService;
-
-    @VisibleForTesting
-    TestActivityExecutor(IWorkflowService workflowService, WorkflowInterceptorBase next) {
-      super(next);
-      this.workflowService = workflowService;
-    }
-
-    @Override
-    public <T> Promise<T> executeActivity(
-        String activityType,
-        Class<T> resultClass,
-        Type resultType,
-        Object[] args,
-        ActivityOptions options) {
-      PollForActivityTaskResponse task = new PollForActivityTaskResponse();
-      task.setScheduleToCloseTimeoutSeconds((int) options.getScheduleToCloseTimeout().getSeconds());
-      task.setHeartbeatTimeoutSeconds((int) options.getHeartbeatTimeout().getSeconds());
-      task.setStartToCloseTimeoutSeconds((int) options.getStartToCloseTimeout().getSeconds());
-      task.setScheduledTimestamp(Duration.ofMillis(System.currentTimeMillis()).toNanos());
-      task.setStartedTimestamp(Duration.ofMillis(System.currentTimeMillis()).toNanos());
-      task.setInput(testEnvironmentOptions.getDataConverter().toData(args));
-      task.setTaskToken("test-task-token".getBytes(StandardCharsets.UTF_8));
-      task.setActivityId(String.valueOf(idSequencer.incrementAndGet()));
-      task.setWorkflowExecution(
-          new WorkflowExecution()
-              .setWorkflowId("test-workflow-id")
-              .setRunId(UUID.randomUUID().toString()));
-      task.setWorkflowType(new WorkflowType().setName("test-workflow"));
-      task.setActivityType(new ActivityType().setName(activityType));
-      Result taskResult = activityTaskHandler.handle(task, NoopScope.getInstance(), false);
-      return Workflow.newPromise(getReply(task, taskResult, resultClass, resultType));
-    }
-
-    @Override
-    public <R> Promise<R> executeLocalActivity(
-        String activityName,
-        Class<R> resultClass,
-        Type resultType,
-        Object[] args,
-        LocalActivityOptions options) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public <R> WorkflowResult<R> executeChildWorkflow(
-        String workflowType,
-        Class<R> resultClass,
-        Type resultType,
-        Object[] args,
-        ChildWorkflowOptions options) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public Random newRandom() {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public Promise<Void> signalExternalWorkflow(
-        String domain, WorkflowExecution execution, String signalName, Object[] args) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public Promise<Void> signalExternalWorkflow(
-        WorkflowExecution execution, String signalName, Object[] args) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public Promise<Void> cancelWorkflow(WorkflowExecution execution) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public void sleep(Duration duration) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public boolean await(Duration timeout, String reason, Supplier<Boolean> unblockCondition) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public void await(String reason, Supplier<Boolean> unblockCondition) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public Promise<Void> newTimer(Duration duration) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public <R> R sideEffect(Class<R> resultClass, Type resultType, Func<R> func) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public <R> R mutableSideEffect(
-        String id, Class<R> resultClass, Type resultType, BiPredicate<R, R> updated, Func<R> func) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public int getVersion(String changeID, int minSupported, int maxSupported) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public void continueAsNew(
-        Optional<String> workflowType, Optional<ContinueAsNewOptions> options, Object[] args) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public void registerQuery(String queryType, Type[] argTypes, Func1<Object[], Object> callback) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public UUID randomUUID() {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public void upsertSearchAttributes(Map<String, Object> searchAttributes) {
-      throw new UnsupportedOperationException("not implemented");
-    }
-
-    private <T> T getReply(
-        PollForActivityTaskResponse task,
-        ActivityTaskHandler.Result response,
-        Class<T> resultClass,
-        Type resultType) {
-      RespondActivityTaskCompletedRequest taskCompleted = response.getTaskCompleted();
-      if (taskCompleted != null) {
-        return testEnvironmentOptions
-            .getDataConverter()
-            .fromData(taskCompleted.getResult(), resultClass, resultType);
-      } else {
-        RespondActivityTaskFailedRequest taskFailed =
-            response.getTaskFailedResult().getTaskFailedRequest();
-        if (taskFailed != null) {
-          String causeClassName = taskFailed.getReason();
-          Class<? extends Exception> causeClass;
-          Exception cause;
-          try {
-            @SuppressWarnings("unchecked") // cc is just to have a place to put this annotation
-            Class<? extends Exception> cc =
-                (Class<? extends Exception>) Class.forName(causeClassName);
-            causeClass = cc;
-            cause =
-                testEnvironmentOptions
-                    .getDataConverter()
-                    .fromData(taskFailed.getDetails(), causeClass, causeClass);
-          } catch (Exception e) {
-            cause = e;
-          }
-          throw new ActivityFailureException(
-              0, task.getActivityType(), task.getActivityId(), cause);
-
+    public TestActivityEnvironmentInternal(TestEnvironmentOptions options) {
+        if (options == null) {
+            this.testEnvironmentOptions = new TestEnvironmentOptions.Builder().build();
         } else {
-          RespondActivityTaskCanceledRequest taskCancelled = response.getTaskCancelled();
-          if (taskCancelled != null) {
-            throw new CancellationException(
-                new String(taskCancelled.getDetails(), StandardCharsets.UTF_8));
-          }
+            this.testEnvironmentOptions = options;
         }
-      }
-      return Defaults.defaultValue(resultClass);
+        activityTaskHandler =
+                new POJOActivityTaskHandler(
+                        new WorkflowServiceWrapper(workflowService),
+                        testEnvironmentOptions.getWorkflowClientOptions().getDomain(),
+                        testEnvironmentOptions.getDataConverter(),
+                        heartbeatExecutor);
+    }
+
+    /**
+     * Register activity implementation objects with a worker. Overwrites previously registered
+     * objects. As activities are reentrant and stateless only one instance per activity type is
+     * registered.
+     *
+     * <p>Implementations that share a worker must implement different interfaces as an activity type
+     * is identified by the activity interface, not by the implementation.
+     *
+     * <p>
+     */
+    @Override
+    public void registerActivitiesImplementations(Object... activityImplementations) {
+        activityTaskHandler.setActivitiesImplementation(activityImplementations);
+    }
+
+    /**
+     * Creates client stub to activities that implement given interface.
+     *
+     * @param activityInterface interface type implemented by activities
+     */
+    @Override
+    public <T> T newActivityStub(Class<T> activityInterface) {
+        ActivityOptions options =
+                new ActivityOptions.Builder().setScheduleToCloseTimeout(Duration.ofDays(1)).build();
+        InvocationHandler invocationHandler =
+                ActivityInvocationHandler.newInstance(
+                        options, new TestActivityExecutor(workflowService, null));
+        invocationHandler = new DeterministicRunnerWrapper(invocationHandler);
+        return ActivityInvocationHandlerBase.newProxy(activityInterface, invocationHandler);
+    }
+
+    @Override
+    public <T> void setActivityHeartbeatListener(Class<T> detailsClass, Consumer<T> listener) {
+        setActivityHeartbeatListener(detailsClass, detailsClass, listener);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> void setActivityHeartbeatListener(
+            Class<T> detailsClass, Type detailsType, Consumer<T> listener) {
+        activityHeartbetListener = new ClassConsumerPair(detailsClass, detailsType, listener);
+    }
+
+    @Override
+    public void setWorkflowService(IWorkflowService workflowService) {
+        IWorkflowService service = new WorkflowServiceWrapper(workflowService);
+        this.workflowService = service;
+        this.activityTaskHandler.setWorkflowService(service);
+    }
+
+    private class TestActivityExecutor extends WorkflowInterceptorBase {
+
+        @SuppressWarnings("UnusedVariable")
+        private final IWorkflowService workflowService;
+
+        TestActivityExecutor(IWorkflowService workflowService, WorkflowInterceptorBase next) {
+            super(next);
+            this.workflowService = workflowService;
+        }
+
+        @Override
+        public <T> Promise<T> executeActivity(
+                String activityType,
+                Class<T> resultClass,
+                Type resultType,
+                Object[] args,
+                ActivityOptions options) {
+            PollForActivityTaskResponse task = new PollForActivityTaskResponse();
+            task.setScheduleToCloseTimeoutSeconds((int) options.getScheduleToCloseTimeout().getSeconds());
+            task.setHeartbeatTimeoutSeconds((int) options.getHeartbeatTimeout().getSeconds());
+            task.setStartToCloseTimeoutSeconds((int) options.getStartToCloseTimeout().getSeconds());
+            task.setScheduledTimestamp(Duration.ofMillis(System.currentTimeMillis()).toNanos());
+            task.setStartedTimestamp(Duration.ofMillis(System.currentTimeMillis()).toNanos());
+            task.setInput(testEnvironmentOptions.getDataConverter().toData(args));
+            task.setTaskToken("test-task-token".getBytes(StandardCharsets.UTF_8));
+            task.setActivityId(String.valueOf(idSequencer.incrementAndGet()));
+            task.setWorkflowExecution(
+                    new WorkflowExecution()
+                            .setWorkflowId("test-workflow-id")
+                            .setRunId(UUID.randomUUID().toString()));
+            task.setWorkflowType(new WorkflowType().setName("test-workflow"));
+            task.setActivityType(new ActivityType().setName(activityType));
+            Result taskResult = activityTaskHandler.handle(task, NoopScope.getInstance(), false);
+            return Workflow.newPromise(getReply(task, taskResult, resultClass, resultType));
+        }
+
+        @Override
+        public <R> Promise<R> executeLocalActivity(
+                String activityName,
+                Class<R> resultClass,
+                Type resultType,
+                Object[] args,
+                LocalActivityOptions options) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public <R> WorkflowResult<R> executeChildWorkflow(
+                String workflowType,
+                Class<R> resultClass,
+                Type resultType,
+                Object[] args,
+                ChildWorkflowOptions options) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public Random newRandom() {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public Promise<Void> signalExternalWorkflow(
+                String domain, WorkflowExecution execution, String signalName, Object[] args) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public Promise<Void> signalExternalWorkflow(
+                WorkflowExecution execution, String signalName, Object[] args) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public Promise<Void> cancelWorkflow(WorkflowExecution execution) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public void sleep(Duration duration) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public boolean await(Duration timeout, String reason, Supplier<Boolean> unblockCondition) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public void await(String reason, Supplier<Boolean> unblockCondition) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public Promise<Void> newTimer(Duration duration) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public <R> R sideEffect(Class<R> resultClass, Type resultType, Func<R> func) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public <R> R mutableSideEffect(
+                String id, Class<R> resultClass, Type resultType, BiPredicate<R, R> updated, Func<R> func) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public int getVersion(String changeID, int minSupported, int maxSupported) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public void continueAsNew(
+                Optional<String> workflowType, Optional<ContinueAsNewOptions> options, Object[] args) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public void registerQuery(String queryType, Type[] argTypes, Func1<Object[], Object> callback) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public UUID randomUUID() {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public void upsertSearchAttributes(Map<String, Object> searchAttributes) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        private <T> T getReply(
+                PollForActivityTaskResponse task,
+                ActivityTaskHandler.Result response,
+                Class<T> resultClass,
+                Type resultType) {
+            RespondActivityTaskCompletedRequest taskCompleted = response.getTaskCompleted();
+            if (taskCompleted != null) {
+                return testEnvironmentOptions
+                        .getDataConverter()
+                        .fromData(taskCompleted.getResult(), resultClass, resultType);
+            } else {
+                RespondActivityTaskFailedRequest taskFailed =
+                        response.getTaskFailedResult().getTaskFailedRequest();
+                if (taskFailed != null) {
+                    String causeClassName = taskFailed.getReason();
+                    Class<? extends Exception> causeClass;
+                    Exception cause;
+                    try {
+                        @SuppressWarnings("unchecked") // cc is just to have a place to put this annotation
+                        Class<? extends Exception> cc =
+                                (Class<? extends Exception>) Class.forName(causeClassName);
+                        causeClass = cc;
+                        cause =
+                                testEnvironmentOptions
+                                        .getDataConverter()
+                                        .fromData(taskFailed.getDetails(), causeClass, causeClass);
+                    } catch (Exception e) {
+                        cause = e;
+                    }
+                    throw new ActivityFailureException(
+                            0, task.getActivityType(), task.getActivityId(), cause);
+
+                } else {
+                    RespondActivityTaskCanceledRequest taskCancelled = response.getTaskCancelled();
+                    if (taskCancelled != null) {
+                        throw new CancellationException(
+                                new String(taskCancelled.getDetails(), StandardCharsets.UTF_8));
+                    }
+                }
+            }
+            return Defaults.defaultValue(resultClass);
+        }
+    }
+
+    private static class ClassConsumerPair<T> {
+
+        final Consumer<T> consumer;
+        final Class<T> valueClass;
+        final Type valueType;
+
+        ClassConsumerPair(Class<T> valueClass, Type valueType, Consumer<T> consumer) {
+            this.valueClass = Objects.requireNonNull(valueClass);
+            this.valueType = Objects.requireNonNull(valueType);
+            this.consumer = Objects.requireNonNull(consumer);
+        }
+    }
+
+    private class WorkflowServiceWrapper implements IWorkflowService {
+
+        private final IWorkflowService impl;
+
+        @Override
+        public ClientOptions getOptions() {
+            return impl.getOptions();
+        }
+
+        @Override
+        public CompletableFuture<Boolean> isHealthy() {
+            return impl.isHealthy();
+        }
+        
+        private WorkflowServiceWrapper(IWorkflowService impl) {
+            if (impl == null) {
+                // Create empty implementation that just ignores all requests.
+                this.impl =
+                        (IWorkflowService)
+                                Proxy.newProxyInstance(
+                                        WorkflowServiceWrapper.class.getClassLoader(),
+                                        new Class<?>[]{IWorkflowService.class},
+                                        (proxy, method, args) -> {
+                                            // noop
+                                            return method.getReturnType().getDeclaredConstructor().newInstance();
+                                        });
+            } else {
+                this.impl = impl;
+            }
+        }
+
+        @Override
+        public RecordActivityTaskHeartbeatResponse RecordActivityTaskHeartbeat(
+                RecordActivityTaskHeartbeatRequest heartbeatRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError,
+                WorkflowExecutionAlreadyCompletedError, TException {
+            if (activityHeartbetListener != null) {
+                Object details =
+                        testEnvironmentOptions
+                                .getDataConverter()
+                                .fromData(
+                                        heartbeatRequest.getDetails(),
+                                        activityHeartbetListener.valueClass,
+                                        activityHeartbetListener.valueType);
+                activityHeartbetListener.consumer.accept(details);
+            }
+            // TODO: Cancellation
+            return impl.RecordActivityTaskHeartbeat(heartbeatRequest);
+        }
+
+        @Override
+        public RecordActivityTaskHeartbeatResponse RecordActivityTaskHeartbeatByID(
+                RecordActivityTaskHeartbeatByIDRequest heartbeatRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError,
+                WorkflowExecutionAlreadyCompletedError, DomainNotActiveError, LimitExceededError,
+                ServiceBusyError, TException {
+            return impl.RecordActivityTaskHeartbeatByID(heartbeatRequest);
+        }
+
+        @Override
+        public void RespondActivityTaskCompleted(RespondActivityTaskCompletedRequest completeRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError,
+                WorkflowExecutionAlreadyCompletedError, TException {
+            impl.RespondActivityTaskCompleted(completeRequest);
+        }
+
+        @Override
+        public void RespondActivityTaskCompletedByID(
+                RespondActivityTaskCompletedByIDRequest completeRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError,
+                WorkflowExecutionAlreadyCompletedError, TException {
+            impl.RespondActivityTaskCompletedByID(completeRequest);
+        }
+
+        @Override
+        public void RespondActivityTaskFailed(RespondActivityTaskFailedRequest failRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError,
+                WorkflowExecutionAlreadyCompletedError, TException {
+            impl.RespondActivityTaskFailed(failRequest);
+        }
+
+        @Override
+        public void RespondActivityTaskFailedByID(RespondActivityTaskFailedByIDRequest failRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError,
+                WorkflowExecutionAlreadyCompletedError, TException {
+            impl.RespondActivityTaskFailedByID(failRequest);
+        }
+
+        @Override
+        public void RespondActivityTaskCanceled(RespondActivityTaskCanceledRequest canceledRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError,
+                WorkflowExecutionAlreadyCompletedError, TException {
+            impl.RespondActivityTaskCanceled(canceledRequest);
+        }
+
+        @Override
+        public void RespondActivityTaskCanceledByID(
+                RespondActivityTaskCanceledByIDRequest canceledRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError,
+                WorkflowExecutionAlreadyCompletedError, TException {
+            impl.RespondActivityTaskCanceledByID(canceledRequest);
+        }
+
+        @Override
+        public void RequestCancelWorkflowExecution(RequestCancelWorkflowExecutionRequest cancelRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError,
+                CancellationAlreadyRequestedError, ServiceBusyError,
+                WorkflowExecutionAlreadyCompletedError, TException {
+            impl.RequestCancelWorkflowExecution(cancelRequest);
+        }
+
+        @Override
+        public void SignalWorkflowExecution(SignalWorkflowExecutionRequest signalRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError,
+                WorkflowExecutionAlreadyCompletedError, ServiceBusyError, TException {
+            impl.SignalWorkflowExecution(signalRequest);
+        }
+
+        @Override
+        public StartWorkflowExecutionResponse SignalWithStartWorkflowExecution(
+                SignalWithStartWorkflowExecutionRequest signalWithStartRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+                DomainNotActiveError, LimitExceededError, WorkflowExecutionAlreadyStartedError,
+                TException {
+            return impl.SignalWithStartWorkflowExecution(signalWithStartRequest);
+        }
+
+        @Override
+        public SignalWithStartWorkflowExecutionAsyncResponse SignalWithStartWorkflowExecutionAsync(
+                SignalWithStartWorkflowExecutionAsyncRequest signalWithStartRequest)
+                throws BadRequestError, WorkflowExecutionAlreadyStartedError, ServiceBusyError,
+                DomainNotActiveError, LimitExceededError, EntityNotExistsError,
+                ClientVersionNotSupportedError, TException {
+            return impl.SignalWithStartWorkflowExecutionAsync(signalWithStartRequest);
+        }
+
+        @Override
+        public ResetWorkflowExecutionResponse ResetWorkflowExecution(
+                ResetWorkflowExecutionRequest resetRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+                DomainNotActiveError, LimitExceededError, ClientVersionNotSupportedError, TException {
+            return impl.ResetWorkflowExecution(resetRequest);
+        }
+
+        @Override
+        public void TerminateWorkflowExecution(TerminateWorkflowExecutionRequest terminateRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError,
+                WorkflowExecutionAlreadyCompletedError, ServiceBusyError, TException {
+            impl.TerminateWorkflowExecution(terminateRequest);
+        }
+
+        @Override
+        public ListOpenWorkflowExecutionsResponse ListOpenWorkflowExecutions(
+                ListOpenWorkflowExecutionsRequest listRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+                TException {
+            return impl.ListOpenWorkflowExecutions(listRequest);
+        }
+
+        @Override
+        public ListClosedWorkflowExecutionsResponse ListClosedWorkflowExecutions(
+                ListClosedWorkflowExecutionsRequest listRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+                TException {
+            return impl.ListClosedWorkflowExecutions(listRequest);
+        }
+
+        @Override
+        public ListWorkflowExecutionsResponse ListWorkflowExecutions(
+                ListWorkflowExecutionsRequest listRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+                ClientVersionNotSupportedError, TException {
+            return impl.ListWorkflowExecutions(listRequest);
+        }
+
+        @Override
+        public ListArchivedWorkflowExecutionsResponse ListArchivedWorkflowExecutions(
+                ListArchivedWorkflowExecutionsRequest listRequest)
+                throws BadRequestError, EntityNotExistsError, ServiceBusyError,
+                ClientVersionNotSupportedError, TException {
+            return impl.ListArchivedWorkflowExecutions(listRequest);
+        }
+
+        @Override
+        public ListWorkflowExecutionsResponse ScanWorkflowExecutions(
+                ListWorkflowExecutionsRequest listRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+                ClientVersionNotSupportedError, TException {
+            return impl.ScanWorkflowExecutions(listRequest);
+        }
+
+        @Override
+        public CountWorkflowExecutionsResponse CountWorkflowExecutions(
+                CountWorkflowExecutionsRequest countRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+                ClientVersionNotSupportedError, TException {
+            return impl.CountWorkflowExecutions(countRequest);
+        }
+
+        @Override
+        public GetSearchAttributesResponse GetSearchAttributes()
+                throws InternalServiceError, ServiceBusyError, ClientVersionNotSupportedError, TException {
+            return impl.GetSearchAttributes();
+        }
+
+        @Override
+        public void RespondQueryTaskCompleted(RespondQueryTaskCompletedRequest completeRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError,
+                WorkflowExecutionAlreadyCompletedError, TException {
+            impl.RespondQueryTaskCompleted(completeRequest);
+        }
+
+        @Override
+        public ResetStickyTaskListResponse ResetStickyTaskList(ResetStickyTaskListRequest resetRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, LimitExceededError,
+                ServiceBusyError, DomainNotActiveError, TException {
+            return impl.ResetStickyTaskList(resetRequest);
+        }
+
+        @Override
+        public QueryWorkflowResponse QueryWorkflow(QueryWorkflowRequest queryRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, QueryFailedError,
+                TException {
+            return impl.QueryWorkflow(queryRequest);
+        }
+
+        @Override
+        public DescribeWorkflowExecutionResponse DescribeWorkflowExecution(
+                DescribeWorkflowExecutionRequest describeRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
+            return impl.DescribeWorkflowExecution(describeRequest);
+        }
+
+        @Override
+        public DescribeTaskListResponse DescribeTaskList(DescribeTaskListRequest request)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
+            return impl.DescribeTaskList(request);
+        }
+
+        @Override
+        public ClusterInfo GetClusterInfo() throws InternalServiceError, ServiceBusyError, TException {
+            return impl.GetClusterInfo();
+        }
+
+        @Override
+        public ListTaskListPartitionsResponse ListTaskListPartitions(
+                ListTaskListPartitionsRequest request)
+                throws BadRequestError, EntityNotExistsError, LimitExceededError, ServiceBusyError,
+                TException {
+            return impl.ListTaskListPartitions(request);
+        }
+
+        @Override
+        public void RefreshWorkflowTasks(RefreshWorkflowTasksRequest request)
+                throws BadRequestError, DomainNotActiveError, ServiceBusyError, EntityNotExistsError,
+                TException {
+            impl.RefreshWorkflowTasks(request);
+        }
+
+        @Override
+        public void RegisterDomain(
+                RegisterDomainRequest registerRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.RegisterDomain(registerRequest, resultHandler);
+        }
+
+        @Override
+        public void DescribeDomain(
+                DescribeDomainRequest describeRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.DescribeDomain(describeRequest, resultHandler);
+        }
+
+        @Override
+        public void ListDomains(ListDomainsRequest listRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.ListDomains(listRequest, resultHandler);
+        }
+
+        @Override
+        public void UpdateDomain(UpdateDomainRequest updateRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.UpdateDomain(updateRequest, resultHandler);
+        }
+
+        @Override
+        public void DeprecateDomain(
+                DeprecateDomainRequest deprecateRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.DeprecateDomain(deprecateRequest, resultHandler);
+        }
+
+        @Override
+        public void RestartWorkflowExecution(
+                RestartWorkflowExecutionRequest restartRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.RestartWorkflowExecution(restartRequest, resultHandler);
+        }
+
+        @Override
+        public void GetTaskListsByDomain(
+                GetTaskListsByDomainRequest request, AsyncMethodCallback resultHandler) throws TException {
+            impl.GetTaskListsByDomain(request, resultHandler);
+        }
+
+        @Override
+        public void StartWorkflowExecution(
+                StartWorkflowExecutionRequest startRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.StartWorkflowExecution(startRequest, resultHandler);
+        }
+
+        @Override
+        public void StartWorkflowExecutionAsync(
+                StartWorkflowExecutionAsyncRequest startRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.StartWorkflowExecutionAsync(startRequest, resultHandler);
+        }
+
+        @Override
+        public void StartWorkflowExecutionWithTimeout(
+                StartWorkflowExecutionRequest startRequest,
+                AsyncMethodCallback resultHandler,
+                Long timeoutInMillis)
+                throws TException {
+            impl.StartWorkflowExecutionWithTimeout(startRequest, resultHandler, timeoutInMillis);
+        }
+
+        @Override
+        public void StartWorkflowExecutionAsyncWithTimeout(
+                StartWorkflowExecutionAsyncRequest startAsyncRequest,
+                AsyncMethodCallback resultHandler,
+                Long timeoutInMillis)
+                throws TException {
+            impl.StartWorkflowExecutionAsyncWithTimeout(
+                    startAsyncRequest, resultHandler, timeoutInMillis);
+        }
+
+        @Override
+        public void GetWorkflowExecutionHistory(
+                GetWorkflowExecutionHistoryRequest getRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.GetWorkflowExecutionHistory(getRequest, resultHandler);
+        }
+
+        @Override
+        public void GetWorkflowExecutionHistoryWithTimeout(
+                GetWorkflowExecutionHistoryRequest getRequest,
+                AsyncMethodCallback resultHandler,
+                Long timeoutInMillis)
+                throws TException {
+            impl.GetWorkflowExecutionHistoryWithTimeout(getRequest, resultHandler, timeoutInMillis);
+        }
+
+        @Override
+        public void PollForDecisionTask(
+                PollForDecisionTaskRequest pollRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.PollForDecisionTask(pollRequest, resultHandler);
+        }
+
+        @Override
+        public void RespondDecisionTaskCompleted(
+                RespondDecisionTaskCompletedRequest completeRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.RespondDecisionTaskCompleted(completeRequest, resultHandler);
+        }
+
+        @Override
+        public void RespondDecisionTaskFailed(
+                RespondDecisionTaskFailedRequest failedRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.RespondDecisionTaskFailed(failedRequest, resultHandler);
+        }
+
+        @Override
+        public void PollForActivityTask(
+                PollForActivityTaskRequest pollRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.PollForActivityTask(pollRequest, resultHandler);
+        }
+
+        @Override
+        public void RecordActivityTaskHeartbeat(
+                RecordActivityTaskHeartbeatRequest heartbeatRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.RecordActivityTaskHeartbeat(heartbeatRequest, resultHandler);
+        }
+
+        @Override
+        public void RecordActivityTaskHeartbeatByID(
+                RecordActivityTaskHeartbeatByIDRequest heartbeatRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.RecordActivityTaskHeartbeatByID(heartbeatRequest, resultHandler);
+        }
+
+        @Override
+        public void RespondActivityTaskCompleted(
+                RespondActivityTaskCompletedRequest completeRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.RespondActivityTaskCompleted(completeRequest, resultHandler);
+        }
+
+        @Override
+        public void RespondActivityTaskCompletedByID(
+                RespondActivityTaskCompletedByIDRequest completeRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.RespondActivityTaskCompletedByID(completeRequest, resultHandler);
+        }
+
+        @Override
+        public void RespondActivityTaskFailed(
+                RespondActivityTaskFailedRequest failRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.RespondActivityTaskFailed(failRequest, resultHandler);
+        }
+
+        @Override
+        public void RespondActivityTaskFailedByID(
+                RespondActivityTaskFailedByIDRequest failRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.RespondActivityTaskFailedByID(failRequest, resultHandler);
+        }
+
+        @Override
+        public void RespondActivityTaskCanceled(
+                RespondActivityTaskCanceledRequest canceledRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.RespondActivityTaskCanceled(canceledRequest, resultHandler);
+        }
+
+        @Override
+        public void RespondActivityTaskCanceledByID(
+                RespondActivityTaskCanceledByIDRequest canceledRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.RespondActivityTaskCanceledByID(canceledRequest, resultHandler);
+        }
+
+        @Override
+        public void RequestCancelWorkflowExecution(
+                RequestCancelWorkflowExecutionRequest cancelRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.RequestCancelWorkflowExecution(cancelRequest, resultHandler);
+        }
+
+        @Override
+        public void SignalWorkflowExecution(
+                SignalWorkflowExecutionRequest signalRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.SignalWorkflowExecution(signalRequest, resultHandler);
+        }
+
+        @Override
+        public void SignalWorkflowExecutionWithTimeout(
+                SignalWorkflowExecutionRequest signalRequest,
+                AsyncMethodCallback resultHandler,
+                Long timeoutInMillis)
+                throws TException {
+            impl.SignalWorkflowExecutionWithTimeout(signalRequest, resultHandler, timeoutInMillis);
+        }
+
+        @Override
+        public void SignalWithStartWorkflowExecution(
+                SignalWithStartWorkflowExecutionRequest signalWithStartRequest,
+                AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.SignalWithStartWorkflowExecution(signalWithStartRequest, resultHandler);
+        }
+
+        @Override
+        public void SignalWithStartWorkflowExecutionAsync(
+                SignalWithStartWorkflowExecutionAsyncRequest signalWithStartRequest,
+                AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.SignalWithStartWorkflowExecutionAsync(signalWithStartRequest, resultHandler);
+        }
+
+        @Override
+        public void ResetWorkflowExecution(
+                ResetWorkflowExecutionRequest resetRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.ResetWorkflowExecution(resetRequest, resultHandler);
+        }
+
+        @Override
+        public void TerminateWorkflowExecution(
+                TerminateWorkflowExecutionRequest terminateRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.TerminateWorkflowExecution(terminateRequest, resultHandler);
+        }
+
+        @Override
+        public void ListOpenWorkflowExecutions(
+                ListOpenWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.ListOpenWorkflowExecutions(listRequest, resultHandler);
+        }
+
+        @Override
+        public void ListClosedWorkflowExecutions(
+                ListClosedWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.ListClosedWorkflowExecutions(listRequest, resultHandler);
+        }
+
+        @Override
+        public void ListWorkflowExecutions(
+                ListWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.ListWorkflowExecutions(listRequest, resultHandler);
+        }
+
+        @Override
+        public void ListArchivedWorkflowExecutions(
+                ListArchivedWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.ListArchivedWorkflowExecutions(listRequest, resultHandler);
+        }
+
+        @Override
+        public void ScanWorkflowExecutions(
+                ListWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.ScanWorkflowExecutions(listRequest, resultHandler);
+        }
+
+        @Override
+        public void CountWorkflowExecutions(
+                CountWorkflowExecutionsRequest countRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.CountWorkflowExecutions(countRequest, resultHandler);
+        }
+
+        @Override
+        public void GetSearchAttributes(AsyncMethodCallback resultHandler) throws TException {
+            impl.GetSearchAttributes(resultHandler);
+        }
+
+        @Override
+        public void RespondQueryTaskCompleted(
+                RespondQueryTaskCompletedRequest completeRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.RespondQueryTaskCompleted(completeRequest, resultHandler);
+        }
+
+        @Override
+        public void ResetStickyTaskList(
+                ResetStickyTaskListRequest resetRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.ResetStickyTaskList(resetRequest, resultHandler);
+        }
+
+        @Override
+        public void QueryWorkflow(QueryWorkflowRequest queryRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.QueryWorkflow(queryRequest, resultHandler);
+        }
+
+        @Override
+        public void DescribeWorkflowExecution(
+                DescribeWorkflowExecutionRequest describeRequest, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.DescribeWorkflowExecution(describeRequest, resultHandler);
+        }
+
+        @Override
+        public void DescribeTaskList(DescribeTaskListRequest request, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.DescribeTaskList(request, resultHandler);
+        }
+
+        @Override
+        public void GetClusterInfo(AsyncMethodCallback resultHandler) throws TException {
+            impl.GetClusterInfo(resultHandler);
+        }
+
+        @Override
+        public void ListTaskListPartitions(
+                ListTaskListPartitionsRequest request, AsyncMethodCallback resultHandler)
+                throws TException {
+            impl.ListTaskListPartitions(request, resultHandler);
+        }
+
+        @Override
+        public void RefreshWorkflowTasks(
+                RefreshWorkflowTasksRequest request, AsyncMethodCallback resultHandler) throws TException {
+            impl.RefreshWorkflowTasks(request, resultHandler);
+        }
+
+        @Override
+        public void RegisterDomain(RegisterDomainRequest registerRequest)
+                throws BadRequestError, InternalServiceError, DomainAlreadyExistsError, TException {
+            impl.RegisterDomain(registerRequest);
+        }
+
+        @Override
+        public DescribeDomainResponse DescribeDomain(DescribeDomainRequest describeRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
+            return impl.DescribeDomain(describeRequest);
+        }
+
+        @Override
+        public ListDomainsResponse ListDomains(ListDomainsRequest listRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+                TException {
+            return impl.ListDomains(listRequest);
+        }
+
+        @Override
+        public UpdateDomainResponse UpdateDomain(UpdateDomainRequest updateRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
+            return impl.UpdateDomain(updateRequest);
+        }
+
+        @Override
+        public void DeprecateDomain(DeprecateDomainRequest deprecateRequest)
+                throws BadRequestError, EntityNotExistsError, LimitExceededError, ServiceBusyError,
+                ClientVersionNotSupportedError, TException {
+            impl.DeprecateDomain(deprecateRequest);
+        }
+
+        @Override
+        public RestartWorkflowExecutionResponse RestartWorkflowExecution(
+                RestartWorkflowExecutionRequest restartRequest)
+                throws BadRequestError, ServiceBusyError, DomainNotActiveError, LimitExceededError,
+                EntityNotExistsError, ClientVersionNotSupportedError, TException {
+            return impl.RestartWorkflowExecution(restartRequest);
+        }
+
+        @Override
+        public GetTaskListsByDomainResponse GetTaskListsByDomain(GetTaskListsByDomainRequest request)
+                throws BadRequestError, EntityNotExistsError, LimitExceededError, ServiceBusyError,
+                ClientVersionNotSupportedError, TException {
+            return impl.GetTaskListsByDomain(request);
+        }
+
+        @Override
+        public StartWorkflowExecutionResponse StartWorkflowExecution(
+                StartWorkflowExecutionRequest startRequest)
+                throws BadRequestError, InternalServiceError, WorkflowExecutionAlreadyStartedError,
+                ServiceBusyError, TException {
+            return impl.StartWorkflowExecution(startRequest);
+        }
+
+        @Override
+        public StartWorkflowExecutionAsyncResponse StartWorkflowExecutionAsync(
+                StartWorkflowExecutionAsyncRequest startRequest)
+                throws BadRequestError, WorkflowExecutionAlreadyStartedError, ServiceBusyError,
+                DomainNotActiveError, LimitExceededError, EntityNotExistsError,
+                ClientVersionNotSupportedError, TException {
+            return impl.StartWorkflowExecutionAsync(startRequest);
+        }
+
+        @Override
+        public GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistory(
+                GetWorkflowExecutionHistoryRequest getRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+                TException {
+            return impl.GetWorkflowExecutionHistory(getRequest);
+        }
+
+        @Override
+        public GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistoryWithTimeout(
+                GetWorkflowExecutionHistoryRequest getRequest, Long timeoutInMillis)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+                TException {
+            return impl.GetWorkflowExecutionHistoryWithTimeout(getRequest, timeoutInMillis);
+        }
+
+        @Override
+        public PollForDecisionTaskResponse PollForDecisionTask(PollForDecisionTaskRequest pollRequest)
+                throws BadRequestError, InternalServiceError, ServiceBusyError, TException {
+            return impl.PollForDecisionTask(pollRequest);
+        }
+
+        @Override
+        public RespondDecisionTaskCompletedResponse RespondDecisionTaskCompleted(
+                RespondDecisionTaskCompletedRequest completeRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError,
+                WorkflowExecutionAlreadyCompletedError, TException {
+            return impl.RespondDecisionTaskCompleted(completeRequest);
+        }
+
+        @Override
+        public void RespondDecisionTaskFailed(RespondDecisionTaskFailedRequest failedRequest)
+                throws BadRequestError, InternalServiceError, EntityNotExistsError,
+                WorkflowExecutionAlreadyCompletedError, TException {
+            impl.RespondDecisionTaskFailed(failedRequest);
+        }
+
+        @Override
+        public PollForActivityTaskResponse PollForActivityTask(PollForActivityTaskRequest pollRequest)
+                throws BadRequestError, InternalServiceError, ServiceBusyError, TException {
+            return impl.PollForActivityTask(pollRequest);
+        }
+
+        @Override
+        public void close() {
+            impl.close();
+        }
     }
-  }
-
-  private static class ClassConsumerPair<T> {
-
-    final Consumer<T> consumer;
-    final Class<T> valueClass;
-    final Type valueType;
-
-    ClassConsumerPair(Class<T> valueClass, Type valueType, Consumer<T> consumer) {
-      this.valueClass = Objects.requireNonNull(valueClass);
-      this.valueType = Objects.requireNonNull(valueType);
-      this.consumer = Objects.requireNonNull(consumer);
-    }
-  }
-
-  private class WorkflowServiceWrapper implements IWorkflowService {
-
-    private final IWorkflowService impl;
-
-    @Override
-    public ClientOptions getOptions() {
-      return impl.getOptions();
-    }
-
-    @Override
-    public CompletableFuture<Boolean> isHealthy() {
-      return impl.isHealthy();
-    }
-
-    @VisibleForTesting
-    private WorkflowServiceWrapper(IWorkflowService impl) {
-      if (impl == null) {
-        // Create empty implementation that just ignores all requests.
-        this.impl =
-            (IWorkflowService)
-                Proxy.newProxyInstance(
-                    WorkflowServiceWrapper.class.getClassLoader(),
-                    new Class<?>[] {IWorkflowService.class},
-                    (proxy, method, args) -> {
-                      // noop
-                      return method.getReturnType().getDeclaredConstructor().newInstance();
-                    });
-      } else {
-        this.impl = impl;
-      }
-    }
-
-    @Override
-    public RecordActivityTaskHeartbeatResponse RecordActivityTaskHeartbeat(
-        RecordActivityTaskHeartbeatRequest heartbeatRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError,
-            WorkflowExecutionAlreadyCompletedError, TException {
-      if (activityHeartbetListener != null) {
-        Object details =
-            testEnvironmentOptions
-                .getDataConverter()
-                .fromData(
-                    heartbeatRequest.getDetails(),
-                    activityHeartbetListener.valueClass,
-                    activityHeartbetListener.valueType);
-        activityHeartbetListener.consumer.accept(details);
-      }
-      // TODO: Cancellation
-      return impl.RecordActivityTaskHeartbeat(heartbeatRequest);
-    }
-
-    @Override
-    public RecordActivityTaskHeartbeatResponse RecordActivityTaskHeartbeatByID(
-        RecordActivityTaskHeartbeatByIDRequest heartbeatRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError,
-            WorkflowExecutionAlreadyCompletedError, DomainNotActiveError, LimitExceededError,
-            ServiceBusyError, TException {
-      return impl.RecordActivityTaskHeartbeatByID(heartbeatRequest);
-    }
-
-    @Override
-    public void RespondActivityTaskCompleted(RespondActivityTaskCompletedRequest completeRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError,
-            WorkflowExecutionAlreadyCompletedError, TException {
-      impl.RespondActivityTaskCompleted(completeRequest);
-    }
-
-    @Override
-    public void RespondActivityTaskCompletedByID(
-        RespondActivityTaskCompletedByIDRequest completeRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError,
-            WorkflowExecutionAlreadyCompletedError, TException {
-      impl.RespondActivityTaskCompletedByID(completeRequest);
-    }
-
-    @Override
-    public void RespondActivityTaskFailed(RespondActivityTaskFailedRequest failRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError,
-            WorkflowExecutionAlreadyCompletedError, TException {
-      impl.RespondActivityTaskFailed(failRequest);
-    }
-
-    @Override
-    public void RespondActivityTaskFailedByID(RespondActivityTaskFailedByIDRequest failRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError,
-            WorkflowExecutionAlreadyCompletedError, TException {
-      impl.RespondActivityTaskFailedByID(failRequest);
-    }
-
-    @Override
-    public void RespondActivityTaskCanceled(RespondActivityTaskCanceledRequest canceledRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError,
-            WorkflowExecutionAlreadyCompletedError, TException {
-      impl.RespondActivityTaskCanceled(canceledRequest);
-    }
-
-    @Override
-    public void RespondActivityTaskCanceledByID(
-        RespondActivityTaskCanceledByIDRequest canceledRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError,
-            WorkflowExecutionAlreadyCompletedError, TException {
-      impl.RespondActivityTaskCanceledByID(canceledRequest);
-    }
-
-    @Override
-    public void RequestCancelWorkflowExecution(RequestCancelWorkflowExecutionRequest cancelRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError,
-            CancellationAlreadyRequestedError, ServiceBusyError,
-            WorkflowExecutionAlreadyCompletedError, TException {
-      impl.RequestCancelWorkflowExecution(cancelRequest);
-    }
-
-    @Override
-    public void SignalWorkflowExecution(SignalWorkflowExecutionRequest signalRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError,
-            WorkflowExecutionAlreadyCompletedError, ServiceBusyError, TException {
-      impl.SignalWorkflowExecution(signalRequest);
-    }
-
-    @Override
-    public StartWorkflowExecutionResponse SignalWithStartWorkflowExecution(
-        SignalWithStartWorkflowExecutionRequest signalWithStartRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-            DomainNotActiveError, LimitExceededError, WorkflowExecutionAlreadyStartedError,
-            TException {
-      return impl.SignalWithStartWorkflowExecution(signalWithStartRequest);
-    }
-
-    @Override
-    public SignalWithStartWorkflowExecutionAsyncResponse SignalWithStartWorkflowExecutionAsync(
-        SignalWithStartWorkflowExecutionAsyncRequest signalWithStartRequest)
-        throws BadRequestError, WorkflowExecutionAlreadyStartedError, ServiceBusyError,
-            DomainNotActiveError, LimitExceededError, EntityNotExistsError,
-            ClientVersionNotSupportedError, TException {
-      return impl.SignalWithStartWorkflowExecutionAsync(signalWithStartRequest);
-    }
-
-    @Override
-    public ResetWorkflowExecutionResponse ResetWorkflowExecution(
-        ResetWorkflowExecutionRequest resetRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-            DomainNotActiveError, LimitExceededError, ClientVersionNotSupportedError, TException {
-      return impl.ResetWorkflowExecution(resetRequest);
-    }
-
-    @Override
-    public void TerminateWorkflowExecution(TerminateWorkflowExecutionRequest terminateRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError,
-            WorkflowExecutionAlreadyCompletedError, ServiceBusyError, TException {
-      impl.TerminateWorkflowExecution(terminateRequest);
-    }
-
-    @Override
-    public ListOpenWorkflowExecutionsResponse ListOpenWorkflowExecutions(
-        ListOpenWorkflowExecutionsRequest listRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-            TException {
-      return impl.ListOpenWorkflowExecutions(listRequest);
-    }
-
-    @Override
-    public ListClosedWorkflowExecutionsResponse ListClosedWorkflowExecutions(
-        ListClosedWorkflowExecutionsRequest listRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-            TException {
-      return impl.ListClosedWorkflowExecutions(listRequest);
-    }
-
-    @Override
-    public ListWorkflowExecutionsResponse ListWorkflowExecutions(
-        ListWorkflowExecutionsRequest listRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-            ClientVersionNotSupportedError, TException {
-      return impl.ListWorkflowExecutions(listRequest);
-    }
-
-    @Override
-    public ListArchivedWorkflowExecutionsResponse ListArchivedWorkflowExecutions(
-        ListArchivedWorkflowExecutionsRequest listRequest)
-        throws BadRequestError, EntityNotExistsError, ServiceBusyError,
-            ClientVersionNotSupportedError, TException {
-      return impl.ListArchivedWorkflowExecutions(listRequest);
-    }
-
-    @Override
-    public ListWorkflowExecutionsResponse ScanWorkflowExecutions(
-        ListWorkflowExecutionsRequest listRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-            ClientVersionNotSupportedError, TException {
-      return impl.ScanWorkflowExecutions(listRequest);
-    }
-
-    @Override
-    public CountWorkflowExecutionsResponse CountWorkflowExecutions(
-        CountWorkflowExecutionsRequest countRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-            ClientVersionNotSupportedError, TException {
-      return impl.CountWorkflowExecutions(countRequest);
-    }
-
-    @Override
-    public GetSearchAttributesResponse GetSearchAttributes()
-        throws InternalServiceError, ServiceBusyError, ClientVersionNotSupportedError, TException {
-      return impl.GetSearchAttributes();
-    }
-
-    @Override
-    public void RespondQueryTaskCompleted(RespondQueryTaskCompletedRequest completeRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError,
-            WorkflowExecutionAlreadyCompletedError, TException {
-      impl.RespondQueryTaskCompleted(completeRequest);
-    }
-
-    @Override
-    public ResetStickyTaskListResponse ResetStickyTaskList(ResetStickyTaskListRequest resetRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, LimitExceededError,
-            ServiceBusyError, DomainNotActiveError, TException {
-      return impl.ResetStickyTaskList(resetRequest);
-    }
-
-    @Override
-    public QueryWorkflowResponse QueryWorkflow(QueryWorkflowRequest queryRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, QueryFailedError,
-            TException {
-      return impl.QueryWorkflow(queryRequest);
-    }
-
-    @Override
-    public DescribeWorkflowExecutionResponse DescribeWorkflowExecution(
-        DescribeWorkflowExecutionRequest describeRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
-      return impl.DescribeWorkflowExecution(describeRequest);
-    }
-
-    @Override
-    public DescribeTaskListResponse DescribeTaskList(DescribeTaskListRequest request)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
-      return impl.DescribeTaskList(request);
-    }
-
-    @Override
-    public ClusterInfo GetClusterInfo() throws InternalServiceError, ServiceBusyError, TException {
-      return impl.GetClusterInfo();
-    }
-
-    @Override
-    public ListTaskListPartitionsResponse ListTaskListPartitions(
-        ListTaskListPartitionsRequest request)
-        throws BadRequestError, EntityNotExistsError, LimitExceededError, ServiceBusyError,
-            TException {
-      return impl.ListTaskListPartitions(request);
-    }
-
-    @Override
-    public void RefreshWorkflowTasks(RefreshWorkflowTasksRequest request)
-        throws BadRequestError, DomainNotActiveError, ServiceBusyError, EntityNotExistsError,
-            TException {
-      impl.RefreshWorkflowTasks(request);
-    }
-
-    @Override
-    public void RegisterDomain(
-        RegisterDomainRequest registerRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.RegisterDomain(registerRequest, resultHandler);
-    }
-
-    @Override
-    public void DescribeDomain(
-        DescribeDomainRequest describeRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.DescribeDomain(describeRequest, resultHandler);
-    }
-
-    @Override
-    public void ListDomains(ListDomainsRequest listRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.ListDomains(listRequest, resultHandler);
-    }
-
-    @Override
-    public void UpdateDomain(UpdateDomainRequest updateRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.UpdateDomain(updateRequest, resultHandler);
-    }
-
-    @Override
-    public void DeprecateDomain(
-        DeprecateDomainRequest deprecateRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.DeprecateDomain(deprecateRequest, resultHandler);
-    }
-
-    @Override
-    public void RestartWorkflowExecution(
-        RestartWorkflowExecutionRequest restartRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.RestartWorkflowExecution(restartRequest, resultHandler);
-    }
-
-    @Override
-    public void GetTaskListsByDomain(
-        GetTaskListsByDomainRequest request, AsyncMethodCallback resultHandler) throws TException {
-      impl.GetTaskListsByDomain(request, resultHandler);
-    }
-
-    @Override
-    public void StartWorkflowExecution(
-        StartWorkflowExecutionRequest startRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.StartWorkflowExecution(startRequest, resultHandler);
-    }
-
-    @Override
-    public void StartWorkflowExecutionAsync(
-        StartWorkflowExecutionAsyncRequest startRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.StartWorkflowExecutionAsync(startRequest, resultHandler);
-    }
-
-    @Override
-    public void StartWorkflowExecutionWithTimeout(
-        StartWorkflowExecutionRequest startRequest,
-        AsyncMethodCallback resultHandler,
-        Long timeoutInMillis)
-        throws TException {
-      impl.StartWorkflowExecutionWithTimeout(startRequest, resultHandler, timeoutInMillis);
-    }
-
-    @Override
-    public void StartWorkflowExecutionAsyncWithTimeout(
-        StartWorkflowExecutionAsyncRequest startAsyncRequest,
-        AsyncMethodCallback resultHandler,
-        Long timeoutInMillis)
-        throws TException {
-      impl.StartWorkflowExecutionAsyncWithTimeout(
-          startAsyncRequest, resultHandler, timeoutInMillis);
-    }
-
-    @Override
-    public void GetWorkflowExecutionHistory(
-        GetWorkflowExecutionHistoryRequest getRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.GetWorkflowExecutionHistory(getRequest, resultHandler);
-    }
-
-    @Override
-    public void GetWorkflowExecutionHistoryWithTimeout(
-        GetWorkflowExecutionHistoryRequest getRequest,
-        AsyncMethodCallback resultHandler,
-        Long timeoutInMillis)
-        throws TException {
-      impl.GetWorkflowExecutionHistoryWithTimeout(getRequest, resultHandler, timeoutInMillis);
-    }
-
-    @Override
-    public void PollForDecisionTask(
-        PollForDecisionTaskRequest pollRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.PollForDecisionTask(pollRequest, resultHandler);
-    }
-
-    @Override
-    public void RespondDecisionTaskCompleted(
-        RespondDecisionTaskCompletedRequest completeRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.RespondDecisionTaskCompleted(completeRequest, resultHandler);
-    }
-
-    @Override
-    public void RespondDecisionTaskFailed(
-        RespondDecisionTaskFailedRequest failedRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.RespondDecisionTaskFailed(failedRequest, resultHandler);
-    }
-
-    @Override
-    public void PollForActivityTask(
-        PollForActivityTaskRequest pollRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.PollForActivityTask(pollRequest, resultHandler);
-    }
-
-    @Override
-    public void RecordActivityTaskHeartbeat(
-        RecordActivityTaskHeartbeatRequest heartbeatRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.RecordActivityTaskHeartbeat(heartbeatRequest, resultHandler);
-    }
-
-    @Override
-    public void RecordActivityTaskHeartbeatByID(
-        RecordActivityTaskHeartbeatByIDRequest heartbeatRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.RecordActivityTaskHeartbeatByID(heartbeatRequest, resultHandler);
-    }
-
-    @Override
-    public void RespondActivityTaskCompleted(
-        RespondActivityTaskCompletedRequest completeRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.RespondActivityTaskCompleted(completeRequest, resultHandler);
-    }
-
-    @Override
-    public void RespondActivityTaskCompletedByID(
-        RespondActivityTaskCompletedByIDRequest completeRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.RespondActivityTaskCompletedByID(completeRequest, resultHandler);
-    }
-
-    @Override
-    public void RespondActivityTaskFailed(
-        RespondActivityTaskFailedRequest failRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.RespondActivityTaskFailed(failRequest, resultHandler);
-    }
-
-    @Override
-    public void RespondActivityTaskFailedByID(
-        RespondActivityTaskFailedByIDRequest failRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.RespondActivityTaskFailedByID(failRequest, resultHandler);
-    }
-
-    @Override
-    public void RespondActivityTaskCanceled(
-        RespondActivityTaskCanceledRequest canceledRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.RespondActivityTaskCanceled(canceledRequest, resultHandler);
-    }
-
-    @Override
-    public void RespondActivityTaskCanceledByID(
-        RespondActivityTaskCanceledByIDRequest canceledRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.RespondActivityTaskCanceledByID(canceledRequest, resultHandler);
-    }
-
-    @Override
-    public void RequestCancelWorkflowExecution(
-        RequestCancelWorkflowExecutionRequest cancelRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.RequestCancelWorkflowExecution(cancelRequest, resultHandler);
-    }
-
-    @Override
-    public void SignalWorkflowExecution(
-        SignalWorkflowExecutionRequest signalRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.SignalWorkflowExecution(signalRequest, resultHandler);
-    }
-
-    @Override
-    public void SignalWorkflowExecutionWithTimeout(
-        SignalWorkflowExecutionRequest signalRequest,
-        AsyncMethodCallback resultHandler,
-        Long timeoutInMillis)
-        throws TException {
-      impl.SignalWorkflowExecutionWithTimeout(signalRequest, resultHandler, timeoutInMillis);
-    }
-
-    @Override
-    public void SignalWithStartWorkflowExecution(
-        SignalWithStartWorkflowExecutionRequest signalWithStartRequest,
-        AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.SignalWithStartWorkflowExecution(signalWithStartRequest, resultHandler);
-    }
-
-    @Override
-    public void SignalWithStartWorkflowExecutionAsync(
-        SignalWithStartWorkflowExecutionAsyncRequest signalWithStartRequest,
-        AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.SignalWithStartWorkflowExecutionAsync(signalWithStartRequest, resultHandler);
-    }
-
-    @Override
-    public void ResetWorkflowExecution(
-        ResetWorkflowExecutionRequest resetRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.ResetWorkflowExecution(resetRequest, resultHandler);
-    }
-
-    @Override
-    public void TerminateWorkflowExecution(
-        TerminateWorkflowExecutionRequest terminateRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.TerminateWorkflowExecution(terminateRequest, resultHandler);
-    }
-
-    @Override
-    public void ListOpenWorkflowExecutions(
-        ListOpenWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.ListOpenWorkflowExecutions(listRequest, resultHandler);
-    }
-
-    @Override
-    public void ListClosedWorkflowExecutions(
-        ListClosedWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.ListClosedWorkflowExecutions(listRequest, resultHandler);
-    }
-
-    @Override
-    public void ListWorkflowExecutions(
-        ListWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.ListWorkflowExecutions(listRequest, resultHandler);
-    }
-
-    @Override
-    public void ListArchivedWorkflowExecutions(
-        ListArchivedWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.ListArchivedWorkflowExecutions(listRequest, resultHandler);
-    }
-
-    @Override
-    public void ScanWorkflowExecutions(
-        ListWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.ScanWorkflowExecutions(listRequest, resultHandler);
-    }
-
-    @Override
-    public void CountWorkflowExecutions(
-        CountWorkflowExecutionsRequest countRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.CountWorkflowExecutions(countRequest, resultHandler);
-    }
-
-    @Override
-    public void GetSearchAttributes(AsyncMethodCallback resultHandler) throws TException {
-      impl.GetSearchAttributes(resultHandler);
-    }
-
-    @Override
-    public void RespondQueryTaskCompleted(
-        RespondQueryTaskCompletedRequest completeRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.RespondQueryTaskCompleted(completeRequest, resultHandler);
-    }
-
-    @Override
-    public void ResetStickyTaskList(
-        ResetStickyTaskListRequest resetRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.ResetStickyTaskList(resetRequest, resultHandler);
-    }
-
-    @Override
-    public void QueryWorkflow(QueryWorkflowRequest queryRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.QueryWorkflow(queryRequest, resultHandler);
-    }
-
-    @Override
-    public void DescribeWorkflowExecution(
-        DescribeWorkflowExecutionRequest describeRequest, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.DescribeWorkflowExecution(describeRequest, resultHandler);
-    }
-
-    @Override
-    public void DescribeTaskList(DescribeTaskListRequest request, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.DescribeTaskList(request, resultHandler);
-    }
-
-    @Override
-    public void GetClusterInfo(AsyncMethodCallback resultHandler) throws TException {
-      impl.GetClusterInfo(resultHandler);
-    }
-
-    @Override
-    public void ListTaskListPartitions(
-        ListTaskListPartitionsRequest request, AsyncMethodCallback resultHandler)
-        throws TException {
-      impl.ListTaskListPartitions(request, resultHandler);
-    }
-
-    @Override
-    public void RefreshWorkflowTasks(
-        RefreshWorkflowTasksRequest request, AsyncMethodCallback resultHandler) throws TException {
-      impl.RefreshWorkflowTasks(request, resultHandler);
-    }
-
-    @Override
-    public void RegisterDomain(RegisterDomainRequest registerRequest)
-        throws BadRequestError, InternalServiceError, DomainAlreadyExistsError, TException {
-      impl.RegisterDomain(registerRequest);
-    }
-
-    @Override
-    public DescribeDomainResponse DescribeDomain(DescribeDomainRequest describeRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
-      return impl.DescribeDomain(describeRequest);
-    }
-
-    @Override
-    public ListDomainsResponse ListDomains(ListDomainsRequest listRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-            TException {
-      return impl.ListDomains(listRequest);
-    }
-
-    @Override
-    public UpdateDomainResponse UpdateDomain(UpdateDomainRequest updateRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
-      return impl.UpdateDomain(updateRequest);
-    }
-
-    @Override
-    public void DeprecateDomain(DeprecateDomainRequest deprecateRequest)
-        throws BadRequestError, EntityNotExistsError, LimitExceededError, ServiceBusyError,
-            ClientVersionNotSupportedError, TException {
-      impl.DeprecateDomain(deprecateRequest);
-    }
-
-    @Override
-    public RestartWorkflowExecutionResponse RestartWorkflowExecution(
-        RestartWorkflowExecutionRequest restartRequest)
-        throws BadRequestError, ServiceBusyError, DomainNotActiveError, LimitExceededError,
-            EntityNotExistsError, ClientVersionNotSupportedError, TException {
-      return impl.RestartWorkflowExecution(restartRequest);
-    }
-
-    @Override
-    public GetTaskListsByDomainResponse GetTaskListsByDomain(GetTaskListsByDomainRequest request)
-        throws BadRequestError, EntityNotExistsError, LimitExceededError, ServiceBusyError,
-            ClientVersionNotSupportedError, TException {
-      return impl.GetTaskListsByDomain(request);
-    }
-
-    @Override
-    public StartWorkflowExecutionResponse StartWorkflowExecution(
-        StartWorkflowExecutionRequest startRequest)
-        throws BadRequestError, InternalServiceError, WorkflowExecutionAlreadyStartedError,
-            ServiceBusyError, TException {
-      return impl.StartWorkflowExecution(startRequest);
-    }
-
-    @Override
-    public StartWorkflowExecutionAsyncResponse StartWorkflowExecutionAsync(
-        StartWorkflowExecutionAsyncRequest startRequest)
-        throws BadRequestError, WorkflowExecutionAlreadyStartedError, ServiceBusyError,
-            DomainNotActiveError, LimitExceededError, EntityNotExistsError,
-            ClientVersionNotSupportedError, TException {
-      return impl.StartWorkflowExecutionAsync(startRequest);
-    }
-
-    @Override
-    public GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistory(
-        GetWorkflowExecutionHistoryRequest getRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-            TException {
-      return impl.GetWorkflowExecutionHistory(getRequest);
-    }
-
-    @Override
-    public GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistoryWithTimeout(
-        GetWorkflowExecutionHistoryRequest getRequest, Long timeoutInMillis)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-            TException {
-      return impl.GetWorkflowExecutionHistoryWithTimeout(getRequest, timeoutInMillis);
-    }
-
-    @Override
-    public PollForDecisionTaskResponse PollForDecisionTask(PollForDecisionTaskRequest pollRequest)
-        throws BadRequestError, InternalServiceError, ServiceBusyError, TException {
-      return impl.PollForDecisionTask(pollRequest);
-    }
-
-    @Override
-    public RespondDecisionTaskCompletedResponse RespondDecisionTaskCompleted(
-        RespondDecisionTaskCompletedRequest completeRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError,
-            WorkflowExecutionAlreadyCompletedError, TException {
-      return impl.RespondDecisionTaskCompleted(completeRequest);
-    }
-
-    @Override
-    public void RespondDecisionTaskFailed(RespondDecisionTaskFailedRequest failedRequest)
-        throws BadRequestError, InternalServiceError, EntityNotExistsError,
-            WorkflowExecutionAlreadyCompletedError, TException {
-      impl.RespondDecisionTaskFailed(failedRequest);
-    }
-
-    @Override
-    public PollForActivityTaskResponse PollForActivityTask(PollForActivityTaskRequest pollRequest)
-        throws BadRequestError, InternalServiceError, ServiceBusyError, TException {
-      return impl.PollForActivityTask(pollRequest);
-    }
-
-    @Override
-    public void close() {
-      impl.close();
-    }
-  }
 }

--- a/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
@@ -17,7 +17,6 @@
 
 package com.uber.cadence.internal.sync;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Defaults;
 import com.uber.cadence.*;
 import com.uber.cadence.GetTaskListsByDomainRequest;
@@ -34,7 +33,6 @@ import com.uber.cadence.testing.TestEnvironmentOptions;
 import com.uber.cadence.workflow.*;
 import com.uber.cadence.workflow.Functions.Func;
 import com.uber.cadence.workflow.Functions.Func1;
-
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
@@ -53,975 +51,974 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-
 import org.apache.thrift.TException;
 import org.apache.thrift.async.AsyncMethodCallback;
 
 public final class TestActivityEnvironmentInternal implements TestActivityEnvironment {
 
-    private final POJOActivityTaskHandler activityTaskHandler;
-    private final TestEnvironmentOptions testEnvironmentOptions;
-    private final AtomicInteger idSequencer = new AtomicInteger();
-    private ClassConsumerPair<Object> activityHeartbetListener;
-    private static final ScheduledExecutorService heartbeatExecutor =
-            Executors.newScheduledThreadPool(20);
-    private IWorkflowService workflowService;
+  private final POJOActivityTaskHandler activityTaskHandler;
+  private final TestEnvironmentOptions testEnvironmentOptions;
+  private final AtomicInteger idSequencer = new AtomicInteger();
+  private ClassConsumerPair<Object> activityHeartbetListener;
+  private static final ScheduledExecutorService heartbeatExecutor =
+      Executors.newScheduledThreadPool(20);
+  private IWorkflowService workflowService;
 
-    public TestActivityEnvironmentInternal(TestEnvironmentOptions options) {
-        if (options == null) {
-            this.testEnvironmentOptions = new TestEnvironmentOptions.Builder().build();
+  public TestActivityEnvironmentInternal(TestEnvironmentOptions options) {
+    if (options == null) {
+      this.testEnvironmentOptions = new TestEnvironmentOptions.Builder().build();
+    } else {
+      this.testEnvironmentOptions = options;
+    }
+    activityTaskHandler =
+        new POJOActivityTaskHandler(
+            new WorkflowServiceWrapper(workflowService),
+            testEnvironmentOptions.getWorkflowClientOptions().getDomain(),
+            testEnvironmentOptions.getDataConverter(),
+            heartbeatExecutor);
+  }
+
+  /**
+   * Register activity implementation objects with a worker. Overwrites previously registered
+   * objects. As activities are reentrant and stateless only one instance per activity type is
+   * registered.
+   *
+   * <p>Implementations that share a worker must implement different interfaces as an activity type
+   * is identified by the activity interface, not by the implementation.
+   *
+   * <p>
+   */
+  @Override
+  public void registerActivitiesImplementations(Object... activityImplementations) {
+    activityTaskHandler.setActivitiesImplementation(activityImplementations);
+  }
+
+  /**
+   * Creates client stub to activities that implement given interface.
+   *
+   * @param activityInterface interface type implemented by activities
+   */
+  @Override
+  public <T> T newActivityStub(Class<T> activityInterface) {
+    ActivityOptions options =
+        new ActivityOptions.Builder().setScheduleToCloseTimeout(Duration.ofDays(1)).build();
+    InvocationHandler invocationHandler =
+        ActivityInvocationHandler.newInstance(
+            options, new TestActivityExecutor(workflowService, null));
+    invocationHandler = new DeterministicRunnerWrapper(invocationHandler);
+    return ActivityInvocationHandlerBase.newProxy(activityInterface, invocationHandler);
+  }
+
+  @Override
+  public <T> void setActivityHeartbeatListener(Class<T> detailsClass, Consumer<T> listener) {
+    setActivityHeartbeatListener(detailsClass, detailsClass, listener);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> void setActivityHeartbeatListener(
+      Class<T> detailsClass, Type detailsType, Consumer<T> listener) {
+    activityHeartbetListener = new ClassConsumerPair(detailsClass, detailsType, listener);
+  }
+
+  @Override
+  public void setWorkflowService(IWorkflowService workflowService) {
+    IWorkflowService service = new WorkflowServiceWrapper(workflowService);
+    this.workflowService = service;
+    this.activityTaskHandler.setWorkflowService(service);
+  }
+
+  private class TestActivityExecutor extends WorkflowInterceptorBase {
+
+    @SuppressWarnings("UnusedVariable")
+    private final IWorkflowService workflowService;
+
+    TestActivityExecutor(IWorkflowService workflowService, WorkflowInterceptorBase next) {
+      super(next);
+      this.workflowService = workflowService;
+    }
+
+    @Override
+    public <T> Promise<T> executeActivity(
+        String activityType,
+        Class<T> resultClass,
+        Type resultType,
+        Object[] args,
+        ActivityOptions options) {
+      PollForActivityTaskResponse task = new PollForActivityTaskResponse();
+      task.setScheduleToCloseTimeoutSeconds((int) options.getScheduleToCloseTimeout().getSeconds());
+      task.setHeartbeatTimeoutSeconds((int) options.getHeartbeatTimeout().getSeconds());
+      task.setStartToCloseTimeoutSeconds((int) options.getStartToCloseTimeout().getSeconds());
+      task.setScheduledTimestamp(Duration.ofMillis(System.currentTimeMillis()).toNanos());
+      task.setStartedTimestamp(Duration.ofMillis(System.currentTimeMillis()).toNanos());
+      task.setInput(testEnvironmentOptions.getDataConverter().toData(args));
+      task.setTaskToken("test-task-token".getBytes(StandardCharsets.UTF_8));
+      task.setActivityId(String.valueOf(idSequencer.incrementAndGet()));
+      task.setWorkflowExecution(
+          new WorkflowExecution()
+              .setWorkflowId("test-workflow-id")
+              .setRunId(UUID.randomUUID().toString()));
+      task.setWorkflowType(new WorkflowType().setName("test-workflow"));
+      task.setActivityType(new ActivityType().setName(activityType));
+      Result taskResult = activityTaskHandler.handle(task, NoopScope.getInstance(), false);
+      return Workflow.newPromise(getReply(task, taskResult, resultClass, resultType));
+    }
+
+    @Override
+    public <R> Promise<R> executeLocalActivity(
+        String activityName,
+        Class<R> resultClass,
+        Type resultType,
+        Object[] args,
+        LocalActivityOptions options) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public <R> WorkflowResult<R> executeChildWorkflow(
+        String workflowType,
+        Class<R> resultClass,
+        Type resultType,
+        Object[] args,
+        ChildWorkflowOptions options) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Random newRandom() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Promise<Void> signalExternalWorkflow(
+        String domain, WorkflowExecution execution, String signalName, Object[] args) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Promise<Void> signalExternalWorkflow(
+        WorkflowExecution execution, String signalName, Object[] args) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Promise<Void> cancelWorkflow(WorkflowExecution execution) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public void sleep(Duration duration) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public boolean await(Duration timeout, String reason, Supplier<Boolean> unblockCondition) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public void await(String reason, Supplier<Boolean> unblockCondition) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Promise<Void> newTimer(Duration duration) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public <R> R sideEffect(Class<R> resultClass, Type resultType, Func<R> func) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public <R> R mutableSideEffect(
+        String id, Class<R> resultClass, Type resultType, BiPredicate<R, R> updated, Func<R> func) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public int getVersion(String changeID, int minSupported, int maxSupported) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public void continueAsNew(
+        Optional<String> workflowType, Optional<ContinueAsNewOptions> options, Object[] args) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public void registerQuery(String queryType, Type[] argTypes, Func1<Object[], Object> callback) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public UUID randomUUID() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public void upsertSearchAttributes(Map<String, Object> searchAttributes) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    private <T> T getReply(
+        PollForActivityTaskResponse task,
+        ActivityTaskHandler.Result response,
+        Class<T> resultClass,
+        Type resultType) {
+      RespondActivityTaskCompletedRequest taskCompleted = response.getTaskCompleted();
+      if (taskCompleted != null) {
+        return testEnvironmentOptions
+            .getDataConverter()
+            .fromData(taskCompleted.getResult(), resultClass, resultType);
+      } else {
+        RespondActivityTaskFailedRequest taskFailed =
+            response.getTaskFailedResult().getTaskFailedRequest();
+        if (taskFailed != null) {
+          String causeClassName = taskFailed.getReason();
+          Class<? extends Exception> causeClass;
+          Exception cause;
+          try {
+            @SuppressWarnings("unchecked") // cc is just to have a place to put this annotation
+            Class<? extends Exception> cc =
+                (Class<? extends Exception>) Class.forName(causeClassName);
+            causeClass = cc;
+            cause =
+                testEnvironmentOptions
+                    .getDataConverter()
+                    .fromData(taskFailed.getDetails(), causeClass, causeClass);
+          } catch (Exception e) {
+            cause = e;
+          }
+          throw new ActivityFailureException(
+              0, task.getActivityType(), task.getActivityId(), cause);
+
         } else {
-            this.testEnvironmentOptions = options;
+          RespondActivityTaskCanceledRequest taskCancelled = response.getTaskCancelled();
+          if (taskCancelled != null) {
+            throw new CancellationException(
+                new String(taskCancelled.getDetails(), StandardCharsets.UTF_8));
+          }
         }
-        activityTaskHandler =
-                new POJOActivityTaskHandler(
-                        new WorkflowServiceWrapper(workflowService),
-                        testEnvironmentOptions.getWorkflowClientOptions().getDomain(),
-                        testEnvironmentOptions.getDataConverter(),
-                        heartbeatExecutor);
+      }
+      return Defaults.defaultValue(resultClass);
     }
+  }
 
-    /**
-     * Register activity implementation objects with a worker. Overwrites previously registered
-     * objects. As activities are reentrant and stateless only one instance per activity type is
-     * registered.
-     *
-     * <p>Implementations that share a worker must implement different interfaces as an activity type
-     * is identified by the activity interface, not by the implementation.
-     *
-     * <p>
-     */
-    @Override
-    public void registerActivitiesImplementations(Object... activityImplementations) {
-        activityTaskHandler.setActivitiesImplementation(activityImplementations);
+  private static class ClassConsumerPair<T> {
+
+    final Consumer<T> consumer;
+    final Class<T> valueClass;
+    final Type valueType;
+
+    ClassConsumerPair(Class<T> valueClass, Type valueType, Consumer<T> consumer) {
+      this.valueClass = Objects.requireNonNull(valueClass);
+      this.valueType = Objects.requireNonNull(valueType);
+      this.consumer = Objects.requireNonNull(consumer);
     }
+  }
 
-    /**
-     * Creates client stub to activities that implement given interface.
-     *
-     * @param activityInterface interface type implemented by activities
-     */
+  private class WorkflowServiceWrapper implements IWorkflowService {
+
+    private final IWorkflowService impl;
+
     @Override
-    public <T> T newActivityStub(Class<T> activityInterface) {
-        ActivityOptions options =
-                new ActivityOptions.Builder().setScheduleToCloseTimeout(Duration.ofDays(1)).build();
-        InvocationHandler invocationHandler =
-                ActivityInvocationHandler.newInstance(
-                        options, new TestActivityExecutor(workflowService, null));
-        invocationHandler = new DeterministicRunnerWrapper(invocationHandler);
-        return ActivityInvocationHandlerBase.newProxy(activityInterface, invocationHandler);
+    public ClientOptions getOptions() {
+      return impl.getOptions();
     }
 
     @Override
-    public <T> void setActivityHeartbeatListener(Class<T> detailsClass, Consumer<T> listener) {
-        setActivityHeartbeatListener(detailsClass, detailsClass, listener);
+    public CompletableFuture<Boolean> isHealthy() {
+      return impl.isHealthy();
+    }
+
+    private WorkflowServiceWrapper(IWorkflowService impl) {
+      if (impl == null) {
+        // Create empty implementation that just ignores all requests.
+        this.impl =
+            (IWorkflowService)
+                Proxy.newProxyInstance(
+                    WorkflowServiceWrapper.class.getClassLoader(),
+                    new Class<?>[] {IWorkflowService.class},
+                    (proxy, method, args) -> {
+                      // noop
+                      return method.getReturnType().getDeclaredConstructor().newInstance();
+                    });
+      } else {
+        this.impl = impl;
+      }
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public <T> void setActivityHeartbeatListener(
-            Class<T> detailsClass, Type detailsType, Consumer<T> listener) {
-        activityHeartbetListener = new ClassConsumerPair(detailsClass, detailsType, listener);
+    public RecordActivityTaskHeartbeatResponse RecordActivityTaskHeartbeat(
+        RecordActivityTaskHeartbeatRequest heartbeatRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError,
+            WorkflowExecutionAlreadyCompletedError, TException {
+      if (activityHeartbetListener != null) {
+        Object details =
+            testEnvironmentOptions
+                .getDataConverter()
+                .fromData(
+                    heartbeatRequest.getDetails(),
+                    activityHeartbetListener.valueClass,
+                    activityHeartbetListener.valueType);
+        activityHeartbetListener.consumer.accept(details);
+      }
+      // TODO: Cancellation
+      return impl.RecordActivityTaskHeartbeat(heartbeatRequest);
     }
 
     @Override
-    public void setWorkflowService(IWorkflowService workflowService) {
-        IWorkflowService service = new WorkflowServiceWrapper(workflowService);
-        this.workflowService = service;
-        this.activityTaskHandler.setWorkflowService(service);
+    public RecordActivityTaskHeartbeatResponse RecordActivityTaskHeartbeatByID(
+        RecordActivityTaskHeartbeatByIDRequest heartbeatRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError,
+            WorkflowExecutionAlreadyCompletedError, DomainNotActiveError, LimitExceededError,
+            ServiceBusyError, TException {
+      return impl.RecordActivityTaskHeartbeatByID(heartbeatRequest);
     }
 
-    private class TestActivityExecutor extends WorkflowInterceptorBase {
-
-        @SuppressWarnings("UnusedVariable")
-        private final IWorkflowService workflowService;
-
-        TestActivityExecutor(IWorkflowService workflowService, WorkflowInterceptorBase next) {
-            super(next);
-            this.workflowService = workflowService;
-        }
-
-        @Override
-        public <T> Promise<T> executeActivity(
-                String activityType,
-                Class<T> resultClass,
-                Type resultType,
-                Object[] args,
-                ActivityOptions options) {
-            PollForActivityTaskResponse task = new PollForActivityTaskResponse();
-            task.setScheduleToCloseTimeoutSeconds((int) options.getScheduleToCloseTimeout().getSeconds());
-            task.setHeartbeatTimeoutSeconds((int) options.getHeartbeatTimeout().getSeconds());
-            task.setStartToCloseTimeoutSeconds((int) options.getStartToCloseTimeout().getSeconds());
-            task.setScheduledTimestamp(Duration.ofMillis(System.currentTimeMillis()).toNanos());
-            task.setStartedTimestamp(Duration.ofMillis(System.currentTimeMillis()).toNanos());
-            task.setInput(testEnvironmentOptions.getDataConverter().toData(args));
-            task.setTaskToken("test-task-token".getBytes(StandardCharsets.UTF_8));
-            task.setActivityId(String.valueOf(idSequencer.incrementAndGet()));
-            task.setWorkflowExecution(
-                    new WorkflowExecution()
-                            .setWorkflowId("test-workflow-id")
-                            .setRunId(UUID.randomUUID().toString()));
-            task.setWorkflowType(new WorkflowType().setName("test-workflow"));
-            task.setActivityType(new ActivityType().setName(activityType));
-            Result taskResult = activityTaskHandler.handle(task, NoopScope.getInstance(), false);
-            return Workflow.newPromise(getReply(task, taskResult, resultClass, resultType));
-        }
-
-        @Override
-        public <R> Promise<R> executeLocalActivity(
-                String activityName,
-                Class<R> resultClass,
-                Type resultType,
-                Object[] args,
-                LocalActivityOptions options) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public <R> WorkflowResult<R> executeChildWorkflow(
-                String workflowType,
-                Class<R> resultClass,
-                Type resultType,
-                Object[] args,
-                ChildWorkflowOptions options) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public Random newRandom() {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public Promise<Void> signalExternalWorkflow(
-                String domain, WorkflowExecution execution, String signalName, Object[] args) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public Promise<Void> signalExternalWorkflow(
-                WorkflowExecution execution, String signalName, Object[] args) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public Promise<Void> cancelWorkflow(WorkflowExecution execution) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public void sleep(Duration duration) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public boolean await(Duration timeout, String reason, Supplier<Boolean> unblockCondition) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public void await(String reason, Supplier<Boolean> unblockCondition) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public Promise<Void> newTimer(Duration duration) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public <R> R sideEffect(Class<R> resultClass, Type resultType, Func<R> func) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public <R> R mutableSideEffect(
-                String id, Class<R> resultClass, Type resultType, BiPredicate<R, R> updated, Func<R> func) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public int getVersion(String changeID, int minSupported, int maxSupported) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public void continueAsNew(
-                Optional<String> workflowType, Optional<ContinueAsNewOptions> options, Object[] args) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public void registerQuery(String queryType, Type[] argTypes, Func1<Object[], Object> callback) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public UUID randomUUID() {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public void upsertSearchAttributes(Map<String, Object> searchAttributes) {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        private <T> T getReply(
-                PollForActivityTaskResponse task,
-                ActivityTaskHandler.Result response,
-                Class<T> resultClass,
-                Type resultType) {
-            RespondActivityTaskCompletedRequest taskCompleted = response.getTaskCompleted();
-            if (taskCompleted != null) {
-                return testEnvironmentOptions
-                        .getDataConverter()
-                        .fromData(taskCompleted.getResult(), resultClass, resultType);
-            } else {
-                RespondActivityTaskFailedRequest taskFailed =
-                        response.getTaskFailedResult().getTaskFailedRequest();
-                if (taskFailed != null) {
-                    String causeClassName = taskFailed.getReason();
-                    Class<? extends Exception> causeClass;
-                    Exception cause;
-                    try {
-                        @SuppressWarnings("unchecked") // cc is just to have a place to put this annotation
-                        Class<? extends Exception> cc =
-                                (Class<? extends Exception>) Class.forName(causeClassName);
-                        causeClass = cc;
-                        cause =
-                                testEnvironmentOptions
-                                        .getDataConverter()
-                                        .fromData(taskFailed.getDetails(), causeClass, causeClass);
-                    } catch (Exception e) {
-                        cause = e;
-                    }
-                    throw new ActivityFailureException(
-                            0, task.getActivityType(), task.getActivityId(), cause);
-
-                } else {
-                    RespondActivityTaskCanceledRequest taskCancelled = response.getTaskCancelled();
-                    if (taskCancelled != null) {
-                        throw new CancellationException(
-                                new String(taskCancelled.getDetails(), StandardCharsets.UTF_8));
-                    }
-                }
-            }
-            return Defaults.defaultValue(resultClass);
-        }
+    @Override
+    public void RespondActivityTaskCompleted(RespondActivityTaskCompletedRequest completeRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError,
+            WorkflowExecutionAlreadyCompletedError, TException {
+      impl.RespondActivityTaskCompleted(completeRequest);
     }
 
-    private static class ClassConsumerPair<T> {
-
-        final Consumer<T> consumer;
-        final Class<T> valueClass;
-        final Type valueType;
-
-        ClassConsumerPair(Class<T> valueClass, Type valueType, Consumer<T> consumer) {
-            this.valueClass = Objects.requireNonNull(valueClass);
-            this.valueType = Objects.requireNonNull(valueType);
-            this.consumer = Objects.requireNonNull(consumer);
-        }
+    @Override
+    public void RespondActivityTaskCompletedByID(
+        RespondActivityTaskCompletedByIDRequest completeRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError,
+            WorkflowExecutionAlreadyCompletedError, TException {
+      impl.RespondActivityTaskCompletedByID(completeRequest);
     }
 
-    private class WorkflowServiceWrapper implements IWorkflowService {
-
-        private final IWorkflowService impl;
-
-        @Override
-        public ClientOptions getOptions() {
-            return impl.getOptions();
-        }
-
-        @Override
-        public CompletableFuture<Boolean> isHealthy() {
-            return impl.isHealthy();
-        }
-        
-        private WorkflowServiceWrapper(IWorkflowService impl) {
-            if (impl == null) {
-                // Create empty implementation that just ignores all requests.
-                this.impl =
-                        (IWorkflowService)
-                                Proxy.newProxyInstance(
-                                        WorkflowServiceWrapper.class.getClassLoader(),
-                                        new Class<?>[]{IWorkflowService.class},
-                                        (proxy, method, args) -> {
-                                            // noop
-                                            return method.getReturnType().getDeclaredConstructor().newInstance();
-                                        });
-            } else {
-                this.impl = impl;
-            }
-        }
-
-        @Override
-        public RecordActivityTaskHeartbeatResponse RecordActivityTaskHeartbeat(
-                RecordActivityTaskHeartbeatRequest heartbeatRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError,
-                WorkflowExecutionAlreadyCompletedError, TException {
-            if (activityHeartbetListener != null) {
-                Object details =
-                        testEnvironmentOptions
-                                .getDataConverter()
-                                .fromData(
-                                        heartbeatRequest.getDetails(),
-                                        activityHeartbetListener.valueClass,
-                                        activityHeartbetListener.valueType);
-                activityHeartbetListener.consumer.accept(details);
-            }
-            // TODO: Cancellation
-            return impl.RecordActivityTaskHeartbeat(heartbeatRequest);
-        }
-
-        @Override
-        public RecordActivityTaskHeartbeatResponse RecordActivityTaskHeartbeatByID(
-                RecordActivityTaskHeartbeatByIDRequest heartbeatRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError,
-                WorkflowExecutionAlreadyCompletedError, DomainNotActiveError, LimitExceededError,
-                ServiceBusyError, TException {
-            return impl.RecordActivityTaskHeartbeatByID(heartbeatRequest);
-        }
-
-        @Override
-        public void RespondActivityTaskCompleted(RespondActivityTaskCompletedRequest completeRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError,
-                WorkflowExecutionAlreadyCompletedError, TException {
-            impl.RespondActivityTaskCompleted(completeRequest);
-        }
-
-        @Override
-        public void RespondActivityTaskCompletedByID(
-                RespondActivityTaskCompletedByIDRequest completeRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError,
-                WorkflowExecutionAlreadyCompletedError, TException {
-            impl.RespondActivityTaskCompletedByID(completeRequest);
-        }
-
-        @Override
-        public void RespondActivityTaskFailed(RespondActivityTaskFailedRequest failRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError,
-                WorkflowExecutionAlreadyCompletedError, TException {
-            impl.RespondActivityTaskFailed(failRequest);
-        }
-
-        @Override
-        public void RespondActivityTaskFailedByID(RespondActivityTaskFailedByIDRequest failRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError,
-                WorkflowExecutionAlreadyCompletedError, TException {
-            impl.RespondActivityTaskFailedByID(failRequest);
-        }
-
-        @Override
-        public void RespondActivityTaskCanceled(RespondActivityTaskCanceledRequest canceledRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError,
-                WorkflowExecutionAlreadyCompletedError, TException {
-            impl.RespondActivityTaskCanceled(canceledRequest);
-        }
-
-        @Override
-        public void RespondActivityTaskCanceledByID(
-                RespondActivityTaskCanceledByIDRequest canceledRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError,
-                WorkflowExecutionAlreadyCompletedError, TException {
-            impl.RespondActivityTaskCanceledByID(canceledRequest);
-        }
-
-        @Override
-        public void RequestCancelWorkflowExecution(RequestCancelWorkflowExecutionRequest cancelRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError,
-                CancellationAlreadyRequestedError, ServiceBusyError,
-                WorkflowExecutionAlreadyCompletedError, TException {
-            impl.RequestCancelWorkflowExecution(cancelRequest);
-        }
-
-        @Override
-        public void SignalWorkflowExecution(SignalWorkflowExecutionRequest signalRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError,
-                WorkflowExecutionAlreadyCompletedError, ServiceBusyError, TException {
-            impl.SignalWorkflowExecution(signalRequest);
-        }
-
-        @Override
-        public StartWorkflowExecutionResponse SignalWithStartWorkflowExecution(
-                SignalWithStartWorkflowExecutionRequest signalWithStartRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-                DomainNotActiveError, LimitExceededError, WorkflowExecutionAlreadyStartedError,
-                TException {
-            return impl.SignalWithStartWorkflowExecution(signalWithStartRequest);
-        }
-
-        @Override
-        public SignalWithStartWorkflowExecutionAsyncResponse SignalWithStartWorkflowExecutionAsync(
-                SignalWithStartWorkflowExecutionAsyncRequest signalWithStartRequest)
-                throws BadRequestError, WorkflowExecutionAlreadyStartedError, ServiceBusyError,
-                DomainNotActiveError, LimitExceededError, EntityNotExistsError,
-                ClientVersionNotSupportedError, TException {
-            return impl.SignalWithStartWorkflowExecutionAsync(signalWithStartRequest);
-        }
-
-        @Override
-        public ResetWorkflowExecutionResponse ResetWorkflowExecution(
-                ResetWorkflowExecutionRequest resetRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-                DomainNotActiveError, LimitExceededError, ClientVersionNotSupportedError, TException {
-            return impl.ResetWorkflowExecution(resetRequest);
-        }
-
-        @Override
-        public void TerminateWorkflowExecution(TerminateWorkflowExecutionRequest terminateRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError,
-                WorkflowExecutionAlreadyCompletedError, ServiceBusyError, TException {
-            impl.TerminateWorkflowExecution(terminateRequest);
-        }
-
-        @Override
-        public ListOpenWorkflowExecutionsResponse ListOpenWorkflowExecutions(
-                ListOpenWorkflowExecutionsRequest listRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-                TException {
-            return impl.ListOpenWorkflowExecutions(listRequest);
-        }
-
-        @Override
-        public ListClosedWorkflowExecutionsResponse ListClosedWorkflowExecutions(
-                ListClosedWorkflowExecutionsRequest listRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-                TException {
-            return impl.ListClosedWorkflowExecutions(listRequest);
-        }
-
-        @Override
-        public ListWorkflowExecutionsResponse ListWorkflowExecutions(
-                ListWorkflowExecutionsRequest listRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-                ClientVersionNotSupportedError, TException {
-            return impl.ListWorkflowExecutions(listRequest);
-        }
-
-        @Override
-        public ListArchivedWorkflowExecutionsResponse ListArchivedWorkflowExecutions(
-                ListArchivedWorkflowExecutionsRequest listRequest)
-                throws BadRequestError, EntityNotExistsError, ServiceBusyError,
-                ClientVersionNotSupportedError, TException {
-            return impl.ListArchivedWorkflowExecutions(listRequest);
-        }
-
-        @Override
-        public ListWorkflowExecutionsResponse ScanWorkflowExecutions(
-                ListWorkflowExecutionsRequest listRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-                ClientVersionNotSupportedError, TException {
-            return impl.ScanWorkflowExecutions(listRequest);
-        }
-
-        @Override
-        public CountWorkflowExecutionsResponse CountWorkflowExecutions(
-                CountWorkflowExecutionsRequest countRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-                ClientVersionNotSupportedError, TException {
-            return impl.CountWorkflowExecutions(countRequest);
-        }
-
-        @Override
-        public GetSearchAttributesResponse GetSearchAttributes()
-                throws InternalServiceError, ServiceBusyError, ClientVersionNotSupportedError, TException {
-            return impl.GetSearchAttributes();
-        }
-
-        @Override
-        public void RespondQueryTaskCompleted(RespondQueryTaskCompletedRequest completeRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError,
-                WorkflowExecutionAlreadyCompletedError, TException {
-            impl.RespondQueryTaskCompleted(completeRequest);
-        }
-
-        @Override
-        public ResetStickyTaskListResponse ResetStickyTaskList(ResetStickyTaskListRequest resetRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, LimitExceededError,
-                ServiceBusyError, DomainNotActiveError, TException {
-            return impl.ResetStickyTaskList(resetRequest);
-        }
-
-        @Override
-        public QueryWorkflowResponse QueryWorkflow(QueryWorkflowRequest queryRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, QueryFailedError,
-                TException {
-            return impl.QueryWorkflow(queryRequest);
-        }
-
-        @Override
-        public DescribeWorkflowExecutionResponse DescribeWorkflowExecution(
-                DescribeWorkflowExecutionRequest describeRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
-            return impl.DescribeWorkflowExecution(describeRequest);
-        }
-
-        @Override
-        public DescribeTaskListResponse DescribeTaskList(DescribeTaskListRequest request)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
-            return impl.DescribeTaskList(request);
-        }
-
-        @Override
-        public ClusterInfo GetClusterInfo() throws InternalServiceError, ServiceBusyError, TException {
-            return impl.GetClusterInfo();
-        }
-
-        @Override
-        public ListTaskListPartitionsResponse ListTaskListPartitions(
-                ListTaskListPartitionsRequest request)
-                throws BadRequestError, EntityNotExistsError, LimitExceededError, ServiceBusyError,
-                TException {
-            return impl.ListTaskListPartitions(request);
-        }
-
-        @Override
-        public void RefreshWorkflowTasks(RefreshWorkflowTasksRequest request)
-                throws BadRequestError, DomainNotActiveError, ServiceBusyError, EntityNotExistsError,
-                TException {
-            impl.RefreshWorkflowTasks(request);
-        }
-
-        @Override
-        public void RegisterDomain(
-                RegisterDomainRequest registerRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.RegisterDomain(registerRequest, resultHandler);
-        }
-
-        @Override
-        public void DescribeDomain(
-                DescribeDomainRequest describeRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.DescribeDomain(describeRequest, resultHandler);
-        }
-
-        @Override
-        public void ListDomains(ListDomainsRequest listRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.ListDomains(listRequest, resultHandler);
-        }
-
-        @Override
-        public void UpdateDomain(UpdateDomainRequest updateRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.UpdateDomain(updateRequest, resultHandler);
-        }
-
-        @Override
-        public void DeprecateDomain(
-                DeprecateDomainRequest deprecateRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.DeprecateDomain(deprecateRequest, resultHandler);
-        }
-
-        @Override
-        public void RestartWorkflowExecution(
-                RestartWorkflowExecutionRequest restartRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.RestartWorkflowExecution(restartRequest, resultHandler);
-        }
-
-        @Override
-        public void GetTaskListsByDomain(
-                GetTaskListsByDomainRequest request, AsyncMethodCallback resultHandler) throws TException {
-            impl.GetTaskListsByDomain(request, resultHandler);
-        }
-
-        @Override
-        public void StartWorkflowExecution(
-                StartWorkflowExecutionRequest startRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.StartWorkflowExecution(startRequest, resultHandler);
-        }
-
-        @Override
-        public void StartWorkflowExecutionAsync(
-                StartWorkflowExecutionAsyncRequest startRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.StartWorkflowExecutionAsync(startRequest, resultHandler);
-        }
-
-        @Override
-        public void StartWorkflowExecutionWithTimeout(
-                StartWorkflowExecutionRequest startRequest,
-                AsyncMethodCallback resultHandler,
-                Long timeoutInMillis)
-                throws TException {
-            impl.StartWorkflowExecutionWithTimeout(startRequest, resultHandler, timeoutInMillis);
-        }
-
-        @Override
-        public void StartWorkflowExecutionAsyncWithTimeout(
-                StartWorkflowExecutionAsyncRequest startAsyncRequest,
-                AsyncMethodCallback resultHandler,
-                Long timeoutInMillis)
-                throws TException {
-            impl.StartWorkflowExecutionAsyncWithTimeout(
-                    startAsyncRequest, resultHandler, timeoutInMillis);
-        }
-
-        @Override
-        public void GetWorkflowExecutionHistory(
-                GetWorkflowExecutionHistoryRequest getRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.GetWorkflowExecutionHistory(getRequest, resultHandler);
-        }
-
-        @Override
-        public void GetWorkflowExecutionHistoryWithTimeout(
-                GetWorkflowExecutionHistoryRequest getRequest,
-                AsyncMethodCallback resultHandler,
-                Long timeoutInMillis)
-                throws TException {
-            impl.GetWorkflowExecutionHistoryWithTimeout(getRequest, resultHandler, timeoutInMillis);
-        }
-
-        @Override
-        public void PollForDecisionTask(
-                PollForDecisionTaskRequest pollRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.PollForDecisionTask(pollRequest, resultHandler);
-        }
-
-        @Override
-        public void RespondDecisionTaskCompleted(
-                RespondDecisionTaskCompletedRequest completeRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.RespondDecisionTaskCompleted(completeRequest, resultHandler);
-        }
-
-        @Override
-        public void RespondDecisionTaskFailed(
-                RespondDecisionTaskFailedRequest failedRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.RespondDecisionTaskFailed(failedRequest, resultHandler);
-        }
-
-        @Override
-        public void PollForActivityTask(
-                PollForActivityTaskRequest pollRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.PollForActivityTask(pollRequest, resultHandler);
-        }
-
-        @Override
-        public void RecordActivityTaskHeartbeat(
-                RecordActivityTaskHeartbeatRequest heartbeatRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.RecordActivityTaskHeartbeat(heartbeatRequest, resultHandler);
-        }
-
-        @Override
-        public void RecordActivityTaskHeartbeatByID(
-                RecordActivityTaskHeartbeatByIDRequest heartbeatRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.RecordActivityTaskHeartbeatByID(heartbeatRequest, resultHandler);
-        }
-
-        @Override
-        public void RespondActivityTaskCompleted(
-                RespondActivityTaskCompletedRequest completeRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.RespondActivityTaskCompleted(completeRequest, resultHandler);
-        }
-
-        @Override
-        public void RespondActivityTaskCompletedByID(
-                RespondActivityTaskCompletedByIDRequest completeRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.RespondActivityTaskCompletedByID(completeRequest, resultHandler);
-        }
-
-        @Override
-        public void RespondActivityTaskFailed(
-                RespondActivityTaskFailedRequest failRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.RespondActivityTaskFailed(failRequest, resultHandler);
-        }
-
-        @Override
-        public void RespondActivityTaskFailedByID(
-                RespondActivityTaskFailedByIDRequest failRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.RespondActivityTaskFailedByID(failRequest, resultHandler);
-        }
-
-        @Override
-        public void RespondActivityTaskCanceled(
-                RespondActivityTaskCanceledRequest canceledRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.RespondActivityTaskCanceled(canceledRequest, resultHandler);
-        }
-
-        @Override
-        public void RespondActivityTaskCanceledByID(
-                RespondActivityTaskCanceledByIDRequest canceledRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.RespondActivityTaskCanceledByID(canceledRequest, resultHandler);
-        }
-
-        @Override
-        public void RequestCancelWorkflowExecution(
-                RequestCancelWorkflowExecutionRequest cancelRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.RequestCancelWorkflowExecution(cancelRequest, resultHandler);
-        }
-
-        @Override
-        public void SignalWorkflowExecution(
-                SignalWorkflowExecutionRequest signalRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.SignalWorkflowExecution(signalRequest, resultHandler);
-        }
-
-        @Override
-        public void SignalWorkflowExecutionWithTimeout(
-                SignalWorkflowExecutionRequest signalRequest,
-                AsyncMethodCallback resultHandler,
-                Long timeoutInMillis)
-                throws TException {
-            impl.SignalWorkflowExecutionWithTimeout(signalRequest, resultHandler, timeoutInMillis);
-        }
-
-        @Override
-        public void SignalWithStartWorkflowExecution(
-                SignalWithStartWorkflowExecutionRequest signalWithStartRequest,
-                AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.SignalWithStartWorkflowExecution(signalWithStartRequest, resultHandler);
-        }
-
-        @Override
-        public void SignalWithStartWorkflowExecutionAsync(
-                SignalWithStartWorkflowExecutionAsyncRequest signalWithStartRequest,
-                AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.SignalWithStartWorkflowExecutionAsync(signalWithStartRequest, resultHandler);
-        }
-
-        @Override
-        public void ResetWorkflowExecution(
-                ResetWorkflowExecutionRequest resetRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.ResetWorkflowExecution(resetRequest, resultHandler);
-        }
-
-        @Override
-        public void TerminateWorkflowExecution(
-                TerminateWorkflowExecutionRequest terminateRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.TerminateWorkflowExecution(terminateRequest, resultHandler);
-        }
-
-        @Override
-        public void ListOpenWorkflowExecutions(
-                ListOpenWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.ListOpenWorkflowExecutions(listRequest, resultHandler);
-        }
-
-        @Override
-        public void ListClosedWorkflowExecutions(
-                ListClosedWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.ListClosedWorkflowExecutions(listRequest, resultHandler);
-        }
-
-        @Override
-        public void ListWorkflowExecutions(
-                ListWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.ListWorkflowExecutions(listRequest, resultHandler);
-        }
-
-        @Override
-        public void ListArchivedWorkflowExecutions(
-                ListArchivedWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.ListArchivedWorkflowExecutions(listRequest, resultHandler);
-        }
-
-        @Override
-        public void ScanWorkflowExecutions(
-                ListWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.ScanWorkflowExecutions(listRequest, resultHandler);
-        }
-
-        @Override
-        public void CountWorkflowExecutions(
-                CountWorkflowExecutionsRequest countRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.CountWorkflowExecutions(countRequest, resultHandler);
-        }
-
-        @Override
-        public void GetSearchAttributes(AsyncMethodCallback resultHandler) throws TException {
-            impl.GetSearchAttributes(resultHandler);
-        }
-
-        @Override
-        public void RespondQueryTaskCompleted(
-                RespondQueryTaskCompletedRequest completeRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.RespondQueryTaskCompleted(completeRequest, resultHandler);
-        }
-
-        @Override
-        public void ResetStickyTaskList(
-                ResetStickyTaskListRequest resetRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.ResetStickyTaskList(resetRequest, resultHandler);
-        }
-
-        @Override
-        public void QueryWorkflow(QueryWorkflowRequest queryRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.QueryWorkflow(queryRequest, resultHandler);
-        }
-
-        @Override
-        public void DescribeWorkflowExecution(
-                DescribeWorkflowExecutionRequest describeRequest, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.DescribeWorkflowExecution(describeRequest, resultHandler);
-        }
-
-        @Override
-        public void DescribeTaskList(DescribeTaskListRequest request, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.DescribeTaskList(request, resultHandler);
-        }
-
-        @Override
-        public void GetClusterInfo(AsyncMethodCallback resultHandler) throws TException {
-            impl.GetClusterInfo(resultHandler);
-        }
-
-        @Override
-        public void ListTaskListPartitions(
-                ListTaskListPartitionsRequest request, AsyncMethodCallback resultHandler)
-                throws TException {
-            impl.ListTaskListPartitions(request, resultHandler);
-        }
-
-        @Override
-        public void RefreshWorkflowTasks(
-                RefreshWorkflowTasksRequest request, AsyncMethodCallback resultHandler) throws TException {
-            impl.RefreshWorkflowTasks(request, resultHandler);
-        }
-
-        @Override
-        public void RegisterDomain(RegisterDomainRequest registerRequest)
-                throws BadRequestError, InternalServiceError, DomainAlreadyExistsError, TException {
-            impl.RegisterDomain(registerRequest);
-        }
-
-        @Override
-        public DescribeDomainResponse DescribeDomain(DescribeDomainRequest describeRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
-            return impl.DescribeDomain(describeRequest);
-        }
-
-        @Override
-        public ListDomainsResponse ListDomains(ListDomainsRequest listRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-                TException {
-            return impl.ListDomains(listRequest);
-        }
-
-        @Override
-        public UpdateDomainResponse UpdateDomain(UpdateDomainRequest updateRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
-            return impl.UpdateDomain(updateRequest);
-        }
-
-        @Override
-        public void DeprecateDomain(DeprecateDomainRequest deprecateRequest)
-                throws BadRequestError, EntityNotExistsError, LimitExceededError, ServiceBusyError,
-                ClientVersionNotSupportedError, TException {
-            impl.DeprecateDomain(deprecateRequest);
-        }
-
-        @Override
-        public RestartWorkflowExecutionResponse RestartWorkflowExecution(
-                RestartWorkflowExecutionRequest restartRequest)
-                throws BadRequestError, ServiceBusyError, DomainNotActiveError, LimitExceededError,
-                EntityNotExistsError, ClientVersionNotSupportedError, TException {
-            return impl.RestartWorkflowExecution(restartRequest);
-        }
-
-        @Override
-        public GetTaskListsByDomainResponse GetTaskListsByDomain(GetTaskListsByDomainRequest request)
-                throws BadRequestError, EntityNotExistsError, LimitExceededError, ServiceBusyError,
-                ClientVersionNotSupportedError, TException {
-            return impl.GetTaskListsByDomain(request);
-        }
-
-        @Override
-        public StartWorkflowExecutionResponse StartWorkflowExecution(
-                StartWorkflowExecutionRequest startRequest)
-                throws BadRequestError, InternalServiceError, WorkflowExecutionAlreadyStartedError,
-                ServiceBusyError, TException {
-            return impl.StartWorkflowExecution(startRequest);
-        }
-
-        @Override
-        public StartWorkflowExecutionAsyncResponse StartWorkflowExecutionAsync(
-                StartWorkflowExecutionAsyncRequest startRequest)
-                throws BadRequestError, WorkflowExecutionAlreadyStartedError, ServiceBusyError,
-                DomainNotActiveError, LimitExceededError, EntityNotExistsError,
-                ClientVersionNotSupportedError, TException {
-            return impl.StartWorkflowExecutionAsync(startRequest);
-        }
-
-        @Override
-        public GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistory(
-                GetWorkflowExecutionHistoryRequest getRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-                TException {
-            return impl.GetWorkflowExecutionHistory(getRequest);
-        }
-
-        @Override
-        public GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistoryWithTimeout(
-                GetWorkflowExecutionHistoryRequest getRequest, Long timeoutInMillis)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-                TException {
-            return impl.GetWorkflowExecutionHistoryWithTimeout(getRequest, timeoutInMillis);
-        }
-
-        @Override
-        public PollForDecisionTaskResponse PollForDecisionTask(PollForDecisionTaskRequest pollRequest)
-                throws BadRequestError, InternalServiceError, ServiceBusyError, TException {
-            return impl.PollForDecisionTask(pollRequest);
-        }
-
-        @Override
-        public RespondDecisionTaskCompletedResponse RespondDecisionTaskCompleted(
-                RespondDecisionTaskCompletedRequest completeRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError,
-                WorkflowExecutionAlreadyCompletedError, TException {
-            return impl.RespondDecisionTaskCompleted(completeRequest);
-        }
-
-        @Override
-        public void RespondDecisionTaskFailed(RespondDecisionTaskFailedRequest failedRequest)
-                throws BadRequestError, InternalServiceError, EntityNotExistsError,
-                WorkflowExecutionAlreadyCompletedError, TException {
-            impl.RespondDecisionTaskFailed(failedRequest);
-        }
-
-        @Override
-        public PollForActivityTaskResponse PollForActivityTask(PollForActivityTaskRequest pollRequest)
-                throws BadRequestError, InternalServiceError, ServiceBusyError, TException {
-            return impl.PollForActivityTask(pollRequest);
-        }
-
-        @Override
-        public void close() {
-            impl.close();
-        }
+    @Override
+    public void RespondActivityTaskFailed(RespondActivityTaskFailedRequest failRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError,
+            WorkflowExecutionAlreadyCompletedError, TException {
+      impl.RespondActivityTaskFailed(failRequest);
     }
+
+    @Override
+    public void RespondActivityTaskFailedByID(RespondActivityTaskFailedByIDRequest failRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError,
+            WorkflowExecutionAlreadyCompletedError, TException {
+      impl.RespondActivityTaskFailedByID(failRequest);
+    }
+
+    @Override
+    public void RespondActivityTaskCanceled(RespondActivityTaskCanceledRequest canceledRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError,
+            WorkflowExecutionAlreadyCompletedError, TException {
+      impl.RespondActivityTaskCanceled(canceledRequest);
+    }
+
+    @Override
+    public void RespondActivityTaskCanceledByID(
+        RespondActivityTaskCanceledByIDRequest canceledRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError,
+            WorkflowExecutionAlreadyCompletedError, TException {
+      impl.RespondActivityTaskCanceledByID(canceledRequest);
+    }
+
+    @Override
+    public void RequestCancelWorkflowExecution(RequestCancelWorkflowExecutionRequest cancelRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError,
+            CancellationAlreadyRequestedError, ServiceBusyError,
+            WorkflowExecutionAlreadyCompletedError, TException {
+      impl.RequestCancelWorkflowExecution(cancelRequest);
+    }
+
+    @Override
+    public void SignalWorkflowExecution(SignalWorkflowExecutionRequest signalRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError,
+            WorkflowExecutionAlreadyCompletedError, ServiceBusyError, TException {
+      impl.SignalWorkflowExecution(signalRequest);
+    }
+
+    @Override
+    public StartWorkflowExecutionResponse SignalWithStartWorkflowExecution(
+        SignalWithStartWorkflowExecutionRequest signalWithStartRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+            DomainNotActiveError, LimitExceededError, WorkflowExecutionAlreadyStartedError,
+            TException {
+      return impl.SignalWithStartWorkflowExecution(signalWithStartRequest);
+    }
+
+    @Override
+    public SignalWithStartWorkflowExecutionAsyncResponse SignalWithStartWorkflowExecutionAsync(
+        SignalWithStartWorkflowExecutionAsyncRequest signalWithStartRequest)
+        throws BadRequestError, WorkflowExecutionAlreadyStartedError, ServiceBusyError,
+            DomainNotActiveError, LimitExceededError, EntityNotExistsError,
+            ClientVersionNotSupportedError, TException {
+      return impl.SignalWithStartWorkflowExecutionAsync(signalWithStartRequest);
+    }
+
+    @Override
+    public ResetWorkflowExecutionResponse ResetWorkflowExecution(
+        ResetWorkflowExecutionRequest resetRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+            DomainNotActiveError, LimitExceededError, ClientVersionNotSupportedError, TException {
+      return impl.ResetWorkflowExecution(resetRequest);
+    }
+
+    @Override
+    public void TerminateWorkflowExecution(TerminateWorkflowExecutionRequest terminateRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError,
+            WorkflowExecutionAlreadyCompletedError, ServiceBusyError, TException {
+      impl.TerminateWorkflowExecution(terminateRequest);
+    }
+
+    @Override
+    public ListOpenWorkflowExecutionsResponse ListOpenWorkflowExecutions(
+        ListOpenWorkflowExecutionsRequest listRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+            TException {
+      return impl.ListOpenWorkflowExecutions(listRequest);
+    }
+
+    @Override
+    public ListClosedWorkflowExecutionsResponse ListClosedWorkflowExecutions(
+        ListClosedWorkflowExecutionsRequest listRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+            TException {
+      return impl.ListClosedWorkflowExecutions(listRequest);
+    }
+
+    @Override
+    public ListWorkflowExecutionsResponse ListWorkflowExecutions(
+        ListWorkflowExecutionsRequest listRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+            ClientVersionNotSupportedError, TException {
+      return impl.ListWorkflowExecutions(listRequest);
+    }
+
+    @Override
+    public ListArchivedWorkflowExecutionsResponse ListArchivedWorkflowExecutions(
+        ListArchivedWorkflowExecutionsRequest listRequest)
+        throws BadRequestError, EntityNotExistsError, ServiceBusyError,
+            ClientVersionNotSupportedError, TException {
+      return impl.ListArchivedWorkflowExecutions(listRequest);
+    }
+
+    @Override
+    public ListWorkflowExecutionsResponse ScanWorkflowExecutions(
+        ListWorkflowExecutionsRequest listRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+            ClientVersionNotSupportedError, TException {
+      return impl.ScanWorkflowExecutions(listRequest);
+    }
+
+    @Override
+    public CountWorkflowExecutionsResponse CountWorkflowExecutions(
+        CountWorkflowExecutionsRequest countRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+            ClientVersionNotSupportedError, TException {
+      return impl.CountWorkflowExecutions(countRequest);
+    }
+
+    @Override
+    public GetSearchAttributesResponse GetSearchAttributes()
+        throws InternalServiceError, ServiceBusyError, ClientVersionNotSupportedError, TException {
+      return impl.GetSearchAttributes();
+    }
+
+    @Override
+    public void RespondQueryTaskCompleted(RespondQueryTaskCompletedRequest completeRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError,
+            WorkflowExecutionAlreadyCompletedError, TException {
+      impl.RespondQueryTaskCompleted(completeRequest);
+    }
+
+    @Override
+    public ResetStickyTaskListResponse ResetStickyTaskList(ResetStickyTaskListRequest resetRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, LimitExceededError,
+            ServiceBusyError, DomainNotActiveError, TException {
+      return impl.ResetStickyTaskList(resetRequest);
+    }
+
+    @Override
+    public QueryWorkflowResponse QueryWorkflow(QueryWorkflowRequest queryRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, QueryFailedError,
+            TException {
+      return impl.QueryWorkflow(queryRequest);
+    }
+
+    @Override
+    public DescribeWorkflowExecutionResponse DescribeWorkflowExecution(
+        DescribeWorkflowExecutionRequest describeRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
+      return impl.DescribeWorkflowExecution(describeRequest);
+    }
+
+    @Override
+    public DescribeTaskListResponse DescribeTaskList(DescribeTaskListRequest request)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
+      return impl.DescribeTaskList(request);
+    }
+
+    @Override
+    public ClusterInfo GetClusterInfo() throws InternalServiceError, ServiceBusyError, TException {
+      return impl.GetClusterInfo();
+    }
+
+    @Override
+    public ListTaskListPartitionsResponse ListTaskListPartitions(
+        ListTaskListPartitionsRequest request)
+        throws BadRequestError, EntityNotExistsError, LimitExceededError, ServiceBusyError,
+            TException {
+      return impl.ListTaskListPartitions(request);
+    }
+
+    @Override
+    public void RefreshWorkflowTasks(RefreshWorkflowTasksRequest request)
+        throws BadRequestError, DomainNotActiveError, ServiceBusyError, EntityNotExistsError,
+            TException {
+      impl.RefreshWorkflowTasks(request);
+    }
+
+    @Override
+    public void RegisterDomain(
+        RegisterDomainRequest registerRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.RegisterDomain(registerRequest, resultHandler);
+    }
+
+    @Override
+    public void DescribeDomain(
+        DescribeDomainRequest describeRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.DescribeDomain(describeRequest, resultHandler);
+    }
+
+    @Override
+    public void ListDomains(ListDomainsRequest listRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.ListDomains(listRequest, resultHandler);
+    }
+
+    @Override
+    public void UpdateDomain(UpdateDomainRequest updateRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.UpdateDomain(updateRequest, resultHandler);
+    }
+
+    @Override
+    public void DeprecateDomain(
+        DeprecateDomainRequest deprecateRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.DeprecateDomain(deprecateRequest, resultHandler);
+    }
+
+    @Override
+    public void RestartWorkflowExecution(
+        RestartWorkflowExecutionRequest restartRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.RestartWorkflowExecution(restartRequest, resultHandler);
+    }
+
+    @Override
+    public void GetTaskListsByDomain(
+        GetTaskListsByDomainRequest request, AsyncMethodCallback resultHandler) throws TException {
+      impl.GetTaskListsByDomain(request, resultHandler);
+    }
+
+    @Override
+    public void StartWorkflowExecution(
+        StartWorkflowExecutionRequest startRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.StartWorkflowExecution(startRequest, resultHandler);
+    }
+
+    @Override
+    public void StartWorkflowExecutionAsync(
+        StartWorkflowExecutionAsyncRequest startRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.StartWorkflowExecutionAsync(startRequest, resultHandler);
+    }
+
+    @Override
+    public void StartWorkflowExecutionWithTimeout(
+        StartWorkflowExecutionRequest startRequest,
+        AsyncMethodCallback resultHandler,
+        Long timeoutInMillis)
+        throws TException {
+      impl.StartWorkflowExecutionWithTimeout(startRequest, resultHandler, timeoutInMillis);
+    }
+
+    @Override
+    public void StartWorkflowExecutionAsyncWithTimeout(
+        StartWorkflowExecutionAsyncRequest startAsyncRequest,
+        AsyncMethodCallback resultHandler,
+        Long timeoutInMillis)
+        throws TException {
+      impl.StartWorkflowExecutionAsyncWithTimeout(
+          startAsyncRequest, resultHandler, timeoutInMillis);
+    }
+
+    @Override
+    public void GetWorkflowExecutionHistory(
+        GetWorkflowExecutionHistoryRequest getRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.GetWorkflowExecutionHistory(getRequest, resultHandler);
+    }
+
+    @Override
+    public void GetWorkflowExecutionHistoryWithTimeout(
+        GetWorkflowExecutionHistoryRequest getRequest,
+        AsyncMethodCallback resultHandler,
+        Long timeoutInMillis)
+        throws TException {
+      impl.GetWorkflowExecutionHistoryWithTimeout(getRequest, resultHandler, timeoutInMillis);
+    }
+
+    @Override
+    public void PollForDecisionTask(
+        PollForDecisionTaskRequest pollRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.PollForDecisionTask(pollRequest, resultHandler);
+    }
+
+    @Override
+    public void RespondDecisionTaskCompleted(
+        RespondDecisionTaskCompletedRequest completeRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.RespondDecisionTaskCompleted(completeRequest, resultHandler);
+    }
+
+    @Override
+    public void RespondDecisionTaskFailed(
+        RespondDecisionTaskFailedRequest failedRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.RespondDecisionTaskFailed(failedRequest, resultHandler);
+    }
+
+    @Override
+    public void PollForActivityTask(
+        PollForActivityTaskRequest pollRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.PollForActivityTask(pollRequest, resultHandler);
+    }
+
+    @Override
+    public void RecordActivityTaskHeartbeat(
+        RecordActivityTaskHeartbeatRequest heartbeatRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.RecordActivityTaskHeartbeat(heartbeatRequest, resultHandler);
+    }
+
+    @Override
+    public void RecordActivityTaskHeartbeatByID(
+        RecordActivityTaskHeartbeatByIDRequest heartbeatRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.RecordActivityTaskHeartbeatByID(heartbeatRequest, resultHandler);
+    }
+
+    @Override
+    public void RespondActivityTaskCompleted(
+        RespondActivityTaskCompletedRequest completeRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.RespondActivityTaskCompleted(completeRequest, resultHandler);
+    }
+
+    @Override
+    public void RespondActivityTaskCompletedByID(
+        RespondActivityTaskCompletedByIDRequest completeRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.RespondActivityTaskCompletedByID(completeRequest, resultHandler);
+    }
+
+    @Override
+    public void RespondActivityTaskFailed(
+        RespondActivityTaskFailedRequest failRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.RespondActivityTaskFailed(failRequest, resultHandler);
+    }
+
+    @Override
+    public void RespondActivityTaskFailedByID(
+        RespondActivityTaskFailedByIDRequest failRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.RespondActivityTaskFailedByID(failRequest, resultHandler);
+    }
+
+    @Override
+    public void RespondActivityTaskCanceled(
+        RespondActivityTaskCanceledRequest canceledRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.RespondActivityTaskCanceled(canceledRequest, resultHandler);
+    }
+
+    @Override
+    public void RespondActivityTaskCanceledByID(
+        RespondActivityTaskCanceledByIDRequest canceledRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.RespondActivityTaskCanceledByID(canceledRequest, resultHandler);
+    }
+
+    @Override
+    public void RequestCancelWorkflowExecution(
+        RequestCancelWorkflowExecutionRequest cancelRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.RequestCancelWorkflowExecution(cancelRequest, resultHandler);
+    }
+
+    @Override
+    public void SignalWorkflowExecution(
+        SignalWorkflowExecutionRequest signalRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.SignalWorkflowExecution(signalRequest, resultHandler);
+    }
+
+    @Override
+    public void SignalWorkflowExecutionWithTimeout(
+        SignalWorkflowExecutionRequest signalRequest,
+        AsyncMethodCallback resultHandler,
+        Long timeoutInMillis)
+        throws TException {
+      impl.SignalWorkflowExecutionWithTimeout(signalRequest, resultHandler, timeoutInMillis);
+    }
+
+    @Override
+    public void SignalWithStartWorkflowExecution(
+        SignalWithStartWorkflowExecutionRequest signalWithStartRequest,
+        AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.SignalWithStartWorkflowExecution(signalWithStartRequest, resultHandler);
+    }
+
+    @Override
+    public void SignalWithStartWorkflowExecutionAsync(
+        SignalWithStartWorkflowExecutionAsyncRequest signalWithStartRequest,
+        AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.SignalWithStartWorkflowExecutionAsync(signalWithStartRequest, resultHandler);
+    }
+
+    @Override
+    public void ResetWorkflowExecution(
+        ResetWorkflowExecutionRequest resetRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.ResetWorkflowExecution(resetRequest, resultHandler);
+    }
+
+    @Override
+    public void TerminateWorkflowExecution(
+        TerminateWorkflowExecutionRequest terminateRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.TerminateWorkflowExecution(terminateRequest, resultHandler);
+    }
+
+    @Override
+    public void ListOpenWorkflowExecutions(
+        ListOpenWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.ListOpenWorkflowExecutions(listRequest, resultHandler);
+    }
+
+    @Override
+    public void ListClosedWorkflowExecutions(
+        ListClosedWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.ListClosedWorkflowExecutions(listRequest, resultHandler);
+    }
+
+    @Override
+    public void ListWorkflowExecutions(
+        ListWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.ListWorkflowExecutions(listRequest, resultHandler);
+    }
+
+    @Override
+    public void ListArchivedWorkflowExecutions(
+        ListArchivedWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.ListArchivedWorkflowExecutions(listRequest, resultHandler);
+    }
+
+    @Override
+    public void ScanWorkflowExecutions(
+        ListWorkflowExecutionsRequest listRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.ScanWorkflowExecutions(listRequest, resultHandler);
+    }
+
+    @Override
+    public void CountWorkflowExecutions(
+        CountWorkflowExecutionsRequest countRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.CountWorkflowExecutions(countRequest, resultHandler);
+    }
+
+    @Override
+    public void GetSearchAttributes(AsyncMethodCallback resultHandler) throws TException {
+      impl.GetSearchAttributes(resultHandler);
+    }
+
+    @Override
+    public void RespondQueryTaskCompleted(
+        RespondQueryTaskCompletedRequest completeRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.RespondQueryTaskCompleted(completeRequest, resultHandler);
+    }
+
+    @Override
+    public void ResetStickyTaskList(
+        ResetStickyTaskListRequest resetRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.ResetStickyTaskList(resetRequest, resultHandler);
+    }
+
+    @Override
+    public void QueryWorkflow(QueryWorkflowRequest queryRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.QueryWorkflow(queryRequest, resultHandler);
+    }
+
+    @Override
+    public void DescribeWorkflowExecution(
+        DescribeWorkflowExecutionRequest describeRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.DescribeWorkflowExecution(describeRequest, resultHandler);
+    }
+
+    @Override
+    public void DescribeTaskList(DescribeTaskListRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.DescribeTaskList(request, resultHandler);
+    }
+
+    @Override
+    public void GetClusterInfo(AsyncMethodCallback resultHandler) throws TException {
+      impl.GetClusterInfo(resultHandler);
+    }
+
+    @Override
+    public void ListTaskListPartitions(
+        ListTaskListPartitionsRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.ListTaskListPartitions(request, resultHandler);
+    }
+
+    @Override
+    public void RefreshWorkflowTasks(
+        RefreshWorkflowTasksRequest request, AsyncMethodCallback resultHandler) throws TException {
+      impl.RefreshWorkflowTasks(request, resultHandler);
+    }
+
+    @Override
+    public void RegisterDomain(RegisterDomainRequest registerRequest)
+        throws BadRequestError, InternalServiceError, DomainAlreadyExistsError, TException {
+      impl.RegisterDomain(registerRequest);
+    }
+
+    @Override
+    public DescribeDomainResponse DescribeDomain(DescribeDomainRequest describeRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
+      return impl.DescribeDomain(describeRequest);
+    }
+
+    @Override
+    public ListDomainsResponse ListDomains(ListDomainsRequest listRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+            TException {
+      return impl.ListDomains(listRequest);
+    }
+
+    @Override
+    public UpdateDomainResponse UpdateDomain(UpdateDomainRequest updateRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, TException {
+      return impl.UpdateDomain(updateRequest);
+    }
+
+    @Override
+    public void DeprecateDomain(DeprecateDomainRequest deprecateRequest)
+        throws BadRequestError, EntityNotExistsError, LimitExceededError, ServiceBusyError,
+            ClientVersionNotSupportedError, TException {
+      impl.DeprecateDomain(deprecateRequest);
+    }
+
+    @Override
+    public RestartWorkflowExecutionResponse RestartWorkflowExecution(
+        RestartWorkflowExecutionRequest restartRequest)
+        throws BadRequestError, ServiceBusyError, DomainNotActiveError, LimitExceededError,
+            EntityNotExistsError, ClientVersionNotSupportedError, TException {
+      return impl.RestartWorkflowExecution(restartRequest);
+    }
+
+    @Override
+    public GetTaskListsByDomainResponse GetTaskListsByDomain(GetTaskListsByDomainRequest request)
+        throws BadRequestError, EntityNotExistsError, LimitExceededError, ServiceBusyError,
+            ClientVersionNotSupportedError, TException {
+      return impl.GetTaskListsByDomain(request);
+    }
+
+    @Override
+    public StartWorkflowExecutionResponse StartWorkflowExecution(
+        StartWorkflowExecutionRequest startRequest)
+        throws BadRequestError, InternalServiceError, WorkflowExecutionAlreadyStartedError,
+            ServiceBusyError, TException {
+      return impl.StartWorkflowExecution(startRequest);
+    }
+
+    @Override
+    public StartWorkflowExecutionAsyncResponse StartWorkflowExecutionAsync(
+        StartWorkflowExecutionAsyncRequest startRequest)
+        throws BadRequestError, WorkflowExecutionAlreadyStartedError, ServiceBusyError,
+            DomainNotActiveError, LimitExceededError, EntityNotExistsError,
+            ClientVersionNotSupportedError, TException {
+      return impl.StartWorkflowExecutionAsync(startRequest);
+    }
+
+    @Override
+    public GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistory(
+        GetWorkflowExecutionHistoryRequest getRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+            TException {
+      return impl.GetWorkflowExecutionHistory(getRequest);
+    }
+
+    @Override
+    public GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistoryWithTimeout(
+        GetWorkflowExecutionHistoryRequest getRequest, Long timeoutInMillis)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
+            TException {
+      return impl.GetWorkflowExecutionHistoryWithTimeout(getRequest, timeoutInMillis);
+    }
+
+    @Override
+    public PollForDecisionTaskResponse PollForDecisionTask(PollForDecisionTaskRequest pollRequest)
+        throws BadRequestError, InternalServiceError, ServiceBusyError, TException {
+      return impl.PollForDecisionTask(pollRequest);
+    }
+
+    @Override
+    public RespondDecisionTaskCompletedResponse RespondDecisionTaskCompleted(
+        RespondDecisionTaskCompletedRequest completeRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError,
+            WorkflowExecutionAlreadyCompletedError, TException {
+      return impl.RespondDecisionTaskCompleted(completeRequest);
+    }
+
+    @Override
+    public void RespondDecisionTaskFailed(RespondDecisionTaskFailedRequest failedRequest)
+        throws BadRequestError, InternalServiceError, EntityNotExistsError,
+            WorkflowExecutionAlreadyCompletedError, TException {
+      impl.RespondDecisionTaskFailed(failedRequest);
+    }
+
+    @Override
+    public PollForActivityTaskResponse PollForActivityTask(PollForActivityTaskRequest pollRequest)
+        throws BadRequestError, InternalServiceError, ServiceBusyError, TException {
+      return impl.PollForActivityTask(pollRequest);
+    }
+
+    @Override
+    public void close() {
+      impl.close();
+    }
+  }
 }

--- a/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
@@ -17,6 +17,7 @@
 
 package com.uber.cadence.internal.sync;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Defaults;
 import com.uber.cadence.*;
 import com.uber.cadence.GetTaskListsByDomainRequest;
@@ -133,6 +134,7 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
     @SuppressWarnings("UnusedVariable")
     private final IWorkflowService workflowService;
 
+    @VisibleForTesting
     TestActivityExecutor(IWorkflowService workflowService, WorkflowInterceptorBase next) {
       super(next);
       this.workflowService = workflowService;
@@ -334,6 +336,7 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
       return impl.isHealthy();
     }
 
+    @VisibleForTesting
     private WorkflowServiceWrapper(IWorkflowService impl) {
       if (impl == null) {
         // Create empty implementation that just ignores all requests.

--- a/src/test/java/com/uber/cadence/internal/replay/ReplaceDeciderDecisionTaskWithHistoryIteratorTest.java
+++ b/src/test/java/com/uber/cadence/internal/replay/ReplaceDeciderDecisionTaskWithHistoryIteratorTest.java
@@ -24,13 +24,11 @@ import com.uber.cadence.*;
 import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.internal.worker.SingleWorkerOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.*;
-
 import org.apache.thrift.TException;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,210 +36,206 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class ReplaceDeciderDecisionTaskWithHistoryIteratorTest {
-    @Mock
-    private IWorkflowService mockService;
+  @Mock private IWorkflowService mockService;
 
-    @Mock
-    private DecisionContextImpl mockContext;
+  @Mock private DecisionContextImpl mockContext;
 
-    @Mock
-    private DecisionsHelper mockedHelper;
+  @Mock private DecisionsHelper mockedHelper;
 
-    private static final int MAXIMUM_PAGE_SIZE = 10000;
-    private final String WORKFLOW_ID = "testWorkflowId";
-    private final String RUN_ID = "testRunId";
-    private final String DOMAIN = "testDomain";
-    private final String START_PAGE_TOKEN = "testPageToken";
-    private final WorkflowExecution WORKFLOW_EXECUTION =
-            new WorkflowExecution().setWorkflowId(WORKFLOW_ID).setRunId(RUN_ID);
-    private final HistoryEvent START_EVENT =
-            new HistoryEvent()
-                    .setWorkflowExecutionStartedEventAttributes(new WorkflowExecutionStartedEventAttributes())
-                    .setEventId(1);
-    private final History HISTORY = new History().setEvents(Collections.singletonList(START_EVENT));
-    private final PollForDecisionTaskResponse task =
-            new PollForDecisionTaskResponse()
-                    .setWorkflowExecution(WORKFLOW_EXECUTION)
-                    .setHistory(HISTORY)
-                    .setNextPageToken(START_PAGE_TOKEN.getBytes());
+  private static final int MAXIMUM_PAGE_SIZE = 10000;
+  private final String WORKFLOW_ID = "testWorkflowId";
+  private final String RUN_ID = "testRunId";
+  private final String DOMAIN = "testDomain";
+  private final String START_PAGE_TOKEN = "testPageToken";
+  private final WorkflowExecution WORKFLOW_EXECUTION =
+      new WorkflowExecution().setWorkflowId(WORKFLOW_ID).setRunId(RUN_ID);
+  private final HistoryEvent START_EVENT =
+      new HistoryEvent()
+          .setWorkflowExecutionStartedEventAttributes(new WorkflowExecutionStartedEventAttributes())
+          .setEventId(1);
+  private final History HISTORY = new History().setEvents(Collections.singletonList(START_EVENT));
+  private final PollForDecisionTaskResponse task =
+      new PollForDecisionTaskResponse()
+          .setWorkflowExecution(WORKFLOW_EXECUTION)
+          .setHistory(HISTORY)
+          .setNextPageToken(START_PAGE_TOKEN.getBytes());
 
-    private Object iterator;
+  private Object iterator;
 
-    private void setupDecisionTaskWithHistoryIteratorImpl() {
-        try {
-            // Find the inner class first
-            Class<?> innerClass = findDecisionTaskWithHistoryIteratorImplClass();
+  private void setupDecisionTaskWithHistoryIteratorImpl() {
+    try {
+      // Find the inner class first
+      Class<?> innerClass = findDecisionTaskWithHistoryIteratorImplClass();
 
-            // Get the constructor with the specific parameter types
-            Constructor<?> constructor =
-                    innerClass.getDeclaredConstructor(
-                            ReplayDecider.class, PollForDecisionTaskResponse.class, Duration.class);
-            constructor.setAccessible(true);
+      // Get the constructor with the specific parameter types
+      Constructor<?> constructor =
+          innerClass.getDeclaredConstructor(
+              ReplayDecider.class, PollForDecisionTaskResponse.class, Duration.class);
 
-            when(mockedHelper.getTask()).thenReturn(task);
-            when(mockContext.getDomain()).thenReturn(DOMAIN);
+      when(mockedHelper.getTask()).thenReturn(task);
+      when(mockContext.getDomain()).thenReturn(DOMAIN);
 
-            // Create an instance of the outer class
-            ReplayDecider outerInstance =
-                    new ReplayDecider(
-                            mockService,
-                            DOMAIN,
-                            new WorkflowType().setName("testWorkflow"),
-                            null,
-                            mockedHelper,
-                            SingleWorkerOptions.newBuilder()
-                                    .setMetricsScope(WorkflowClientOptions.defaultInstance().getMetricsScope())
-                                    .build(),
-                            null);
+      // Create an instance of the outer class
+      ReplayDecider outerInstance =
+          new ReplayDecider(
+              mockService,
+              DOMAIN,
+              new WorkflowType().setName("testWorkflow"),
+              null,
+              mockedHelper,
+              SingleWorkerOptions.newBuilder()
+                  .setMetricsScope(WorkflowClientOptions.defaultInstance().getMetricsScope())
+                  .build(),
+              null);
 
-            // Create the instance
-            iterator = constructor.newInstance(outerInstance, task, Duration.ofSeconds(10));
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException("Failed to set up test: " + e.getMessage(), e);
-        }
+      // Create the instance
+      iterator = constructor.newInstance(outerInstance, task, Duration.ofSeconds(10));
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new RuntimeException("Failed to set up test: " + e.getMessage(), e);
     }
+  }
 
-    // Helper method to find the inner class
-    private Class<?> findDecisionTaskWithHistoryIteratorImplClass() {
-        for (Class<?> declaredClass : ReplayDecider.class.getDeclaredClasses()) {
-            if (declaredClass.getSimpleName().equals("DecisionTaskWithHistoryIteratorImpl")) {
-                return declaredClass;
-            }
-        }
-        throw new RuntimeException("Could not find DecisionTaskWithHistoryIteratorImpl inner class");
+  // Helper method to find the inner class
+  private Class<?> findDecisionTaskWithHistoryIteratorImplClass() {
+    for (Class<?> declaredClass : ReplayDecider.class.getDeclaredClasses()) {
+      if (declaredClass.getSimpleName().equals("DecisionTaskWithHistoryIteratorImpl")) {
+        return declaredClass;
+      }
     }
+    throw new RuntimeException("Could not find DecisionTaskWithHistoryIteratorImpl inner class");
+  }
 
-    @Before
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
-        setupDecisionTaskWithHistoryIteratorImpl();
-    }
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    setupDecisionTaskWithHistoryIteratorImpl();
+  }
 
-    @Test
-    public void testGetHistoryWithSinglePageOfEvents()
-            throws TException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        // Arrange
-        List<HistoryEvent> events = Arrays.asList(createMockHistoryEvent(2), createMockHistoryEvent(3));
-        History mockHistory = new History().setEvents(events);
-        when(mockService.GetWorkflowExecutionHistory(
+  @Test
+  public void testGetHistoryWithSinglePageOfEvents()
+      throws TException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    // Arrange
+    List<HistoryEvent> events = Arrays.asList(createMockHistoryEvent(2), createMockHistoryEvent(3));
+    History mockHistory = new History().setEvents(events);
+    when(mockService.GetWorkflowExecutionHistory(
+            new GetWorkflowExecutionHistoryRequest()
+                .setDomain(DOMAIN)
+                .setNextPageToken(START_PAGE_TOKEN.getBytes())
+                .setExecution(WORKFLOW_EXECUTION)
+                .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
+        .thenReturn(new GetWorkflowExecutionHistoryResponse().setHistory(mockHistory));
+
+    // Act & Assert
+    Method wrapperMethod = iterator.getClass().getMethod("getHistory");
+
+    Object result = wrapperMethod.invoke(iterator);
+    Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
+    assertTrue(historyIterator.hasNext());
+    assertEquals(START_EVENT.getEventId(), historyIterator.next().getEventId());
+    assertTrue(historyIterator.hasNext());
+    assertEquals(events.get(0).getEventId(), historyIterator.next().getEventId());
+    assertTrue(historyIterator.hasNext());
+    assertEquals(events.get(1).getEventId(), historyIterator.next().getEventId());
+    assertFalse(historyIterator.hasNext());
+  }
+
+  @Test
+  public void testGetHistoryWithMultiplePages()
+      throws TException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    // First page events
+    List<HistoryEvent> firstPageEvents =
+        Arrays.asList(createMockHistoryEvent(1), createMockHistoryEvent(2));
+    History firstHistory = new History().setEvents(firstPageEvents);
+    String firstPageToken = "firstPageToken";
+    when(mockService.GetWorkflowExecutionHistory(
+            eq(
                 new GetWorkflowExecutionHistoryRequest()
-                        .setDomain(DOMAIN)
-                        .setNextPageToken(START_PAGE_TOKEN.getBytes())
-                        .setExecution(WORKFLOW_EXECUTION)
-                        .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
-                .thenReturn(new GetWorkflowExecutionHistoryResponse().setHistory(mockHistory));
+                    .setDomain(DOMAIN)
+                    .setNextPageToken(START_PAGE_TOKEN.getBytes())
+                    .setExecution(WORKFLOW_EXECUTION)
+                    .setMaximumPageSize(MAXIMUM_PAGE_SIZE))))
+        .thenReturn(
+            new GetWorkflowExecutionHistoryResponse()
+                .setHistory(firstHistory)
+                .setNextPageToken(firstPageToken.getBytes()));
 
-        // Act & Assert
-        Method wrapperMethod = iterator.getClass().getMethod("getHistory");
-
-        Object result = wrapperMethod.invoke(iterator);
-        Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
-        assertTrue(historyIterator.hasNext());
-        assertEquals(START_EVENT.getEventId(), historyIterator.next().getEventId());
-        assertTrue(historyIterator.hasNext());
-        assertEquals(events.get(0).getEventId(), historyIterator.next().getEventId());
-        assertTrue(historyIterator.hasNext());
-        assertEquals(events.get(1).getEventId(), historyIterator.next().getEventId());
-        assertFalse(historyIterator.hasNext());
-    }
-
-    @Test
-    public void testGetHistoryWithMultiplePages()
-            throws TException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        // First page events
-        List<HistoryEvent> firstPageEvents =
-                Arrays.asList(createMockHistoryEvent(1), createMockHistoryEvent(2));
-        History firstHistory = new History().setEvents(firstPageEvents);
-        String firstPageToken = "firstPageToken";
-        when(mockService.GetWorkflowExecutionHistory(
-                eq(
-                        new GetWorkflowExecutionHistoryRequest()
-                                .setDomain(DOMAIN)
-                                .setNextPageToken(START_PAGE_TOKEN.getBytes())
-                                .setExecution(WORKFLOW_EXECUTION)
-                                .setMaximumPageSize(MAXIMUM_PAGE_SIZE))))
-                .thenReturn(
-                        new GetWorkflowExecutionHistoryResponse()
-                                .setHistory(firstHistory)
-                                .setNextPageToken(firstPageToken.getBytes()));
-
-        // Second page events
-        List<HistoryEvent> secondPageEvents =
-                Arrays.asList(createMockHistoryEvent(3), createMockHistoryEvent(4));
-        History secondHistory = new History().setEvents(secondPageEvents);
-        when(mockService.GetWorkflowExecutionHistory(
-                eq(
-                        new GetWorkflowExecutionHistoryRequest()
-                                .setDomain(DOMAIN)
-                                .setNextPageToken(firstPageToken.getBytes())
-                                .setExecution(WORKFLOW_EXECUTION)
-                                .setMaximumPageSize(MAXIMUM_PAGE_SIZE))))
-                .thenReturn(new GetWorkflowExecutionHistoryResponse().setHistory(secondHistory));
-
-        // Act & Assert
-        Method wrapperMethod = iterator.getClass().getMethod("getHistory");
-
-        Object result = wrapperMethod.invoke(iterator);
-        Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
-        // Check first page events
-        assertEquals(START_EVENT.getEventId(), historyIterator.next().getEventId());
-        assertEquals(firstPageEvents.get(0).getEventId(), historyIterator.next().getEventId());
-        assertEquals(firstPageEvents.get(1).getEventId(), historyIterator.next().getEventId());
-
-        // Check second page events
-        assertEquals(secondPageEvents.get(0).getEventId(), historyIterator.next().getEventId());
-        assertEquals(secondPageEvents.get(1).getEventId(), historyIterator.next().getEventId());
-
-        assertFalse(historyIterator.hasNext());
-    }
-
-    @Test(expected = Error.class)
-    public void testGetHistoryFailure()
-            throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, TException {
-        when(mockService.GetWorkflowExecutionHistory(
+    // Second page events
+    List<HistoryEvent> secondPageEvents =
+        Arrays.asList(createMockHistoryEvent(3), createMockHistoryEvent(4));
+    History secondHistory = new History().setEvents(secondPageEvents);
+    when(mockService.GetWorkflowExecutionHistory(
+            eq(
                 new GetWorkflowExecutionHistoryRequest()
-                        .setDomain(DOMAIN)
-                        .setNextPageToken(START_PAGE_TOKEN.getBytes())
-                        .setExecution(WORKFLOW_EXECUTION)
-                        .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
-                .thenThrow(new TException());
+                    .setDomain(DOMAIN)
+                    .setNextPageToken(firstPageToken.getBytes())
+                    .setExecution(WORKFLOW_EXECUTION)
+                    .setMaximumPageSize(MAXIMUM_PAGE_SIZE))))
+        .thenReturn(new GetWorkflowExecutionHistoryResponse().setHistory(secondHistory));
 
-        // Act & Assert
-        Method wrapperMethod = iterator.getClass().getMethod("getHistory");
+    // Act & Assert
+    Method wrapperMethod = iterator.getClass().getMethod("getHistory");
 
-        Object result = wrapperMethod.invoke(iterator);
-        Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
-        historyIterator.next();
+    Object result = wrapperMethod.invoke(iterator);
+    Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
+    // Check first page events
+    assertEquals(START_EVENT.getEventId(), historyIterator.next().getEventId());
+    assertEquals(firstPageEvents.get(0).getEventId(), historyIterator.next().getEventId());
+    assertEquals(firstPageEvents.get(1).getEventId(), historyIterator.next().getEventId());
 
-        historyIterator.next(); // This should throw an Error due to timeout
-    }
+    // Check second page events
+    assertEquals(secondPageEvents.get(0).getEventId(), historyIterator.next().getEventId());
+    assertEquals(secondPageEvents.get(1).getEventId(), historyIterator.next().getEventId());
 
-    @Test(expected = Error.class)
-    public void testEmptyHistory()
-            throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, TException {
-        when(mockService.GetWorkflowExecutionHistory(
-                new GetWorkflowExecutionHistoryRequest()
-                        .setDomain(DOMAIN)
-                        .setNextPageToken(START_PAGE_TOKEN.getBytes())
-                        .setExecution(WORKFLOW_EXECUTION)
-                        .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
-                .thenReturn(
-                        new GetWorkflowExecutionHistoryResponse()
-                                .setHistory(new History().setEvents(new ArrayList<>())));
+    assertFalse(historyIterator.hasNext());
+  }
 
-        // Act & Assert
-        Method wrapperMethod = iterator.getClass().getMethod("getHistory");
+  @Test(expected = Error.class)
+  public void testGetHistoryFailure()
+      throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, TException {
+    when(mockService.GetWorkflowExecutionHistory(
+            new GetWorkflowExecutionHistoryRequest()
+                .setDomain(DOMAIN)
+                .setNextPageToken(START_PAGE_TOKEN.getBytes())
+                .setExecution(WORKFLOW_EXECUTION)
+                .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
+        .thenThrow(new TException());
 
-        Object result = wrapperMethod.invoke(iterator);
-        Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
-        historyIterator.next();
+    // Act & Assert
+    Method wrapperMethod = iterator.getClass().getMethod("getHistory");
 
-        historyIterator.next(); // This should throw an Error due to timeout
-    }
+    Object result = wrapperMethod.invoke(iterator);
+    Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
+    historyIterator.next();
 
-    // Helper method to create mock HistoryEvent
-    private HistoryEvent createMockHistoryEvent(int eventId) {
-        return new HistoryEvent().setEventId(eventId);
-    }
+    historyIterator.next(); // This should throw an Error due to timeout
+  }
+
+  @Test(expected = Error.class)
+  public void testEmptyHistory()
+      throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, TException {
+    when(mockService.GetWorkflowExecutionHistory(
+            new GetWorkflowExecutionHistoryRequest()
+                .setDomain(DOMAIN)
+                .setNextPageToken(START_PAGE_TOKEN.getBytes())
+                .setExecution(WORKFLOW_EXECUTION)
+                .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
+        .thenReturn(
+            new GetWorkflowExecutionHistoryResponse()
+                .setHistory(new History().setEvents(new ArrayList<>())));
+
+    // Act & Assert
+    Method wrapperMethod = iterator.getClass().getMethod("getHistory");
+
+    Object result = wrapperMethod.invoke(iterator);
+    Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
+    historyIterator.next();
+
+    historyIterator.next(); // This should throw an Error due to timeout
+  }
+
+  // Helper method to create mock HistoryEvent
+  private HistoryEvent createMockHistoryEvent(int eventId) {
+    return new HistoryEvent().setEventId(eventId);
+  }
 }

--- a/src/test/java/com/uber/cadence/internal/replay/ReplaceDeciderDecisionTaskWithHistoryIteratorTest.java
+++ b/src/test/java/com/uber/cadence/internal/replay/ReplaceDeciderDecisionTaskWithHistoryIteratorTest.java
@@ -1,0 +1,242 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.replay;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.uber.cadence.*;
+import com.uber.cadence.client.WorkflowClientOptions;
+import com.uber.cadence.internal.worker.SingleWorkerOptions;
+import com.uber.cadence.serviceclient.IWorkflowService;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.*;
+import org.apache.thrift.TException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ReplaceDeciderDecisionTaskWithHistoryIteratorTest {
+  @Mock private IWorkflowService mockService;
+
+  @Mock private DecisionContextImpl mockContext;
+
+  @Mock private DecisionsHelper mockedHelper;
+
+  private static final int MAXIMUM_PAGE_SIZE = 10000;
+  private final String WORKFLOW_ID = "testWorkflowId";
+  private final String RUN_ID = "testRunId";
+  private final String DOMAIN = "testDomain";
+  private final String START_PAGE_TOKEN = "testPageToken";
+  private final WorkflowExecution WORKFLOW_EXECUTION =
+      new WorkflowExecution().setWorkflowId(WORKFLOW_ID).setRunId(RUN_ID);
+  private final HistoryEvent START_EVENT =
+      new HistoryEvent()
+          .setWorkflowExecutionStartedEventAttributes(new WorkflowExecutionStartedEventAttributes())
+          .setEventId(1);
+  private final History HISTORY = new History().setEvents(Collections.singletonList(START_EVENT));
+  private final PollForDecisionTaskResponse task =
+      new PollForDecisionTaskResponse()
+          .setWorkflowExecution(WORKFLOW_EXECUTION)
+          .setHistory(HISTORY)
+          .setNextPageToken(START_PAGE_TOKEN.getBytes());
+
+  private Object iterator;
+
+  private void setupDecisionTaskWithHistoryIteratorImpl() {
+    try {
+      // Find the inner class first
+      Class<?> innerClass = findDecisionTaskWithHistoryIteratorImplClass();
+
+      // Get the constructor with the specific parameter types
+      Constructor<?> constructor =
+          innerClass.getDeclaredConstructor(
+              ReplayDecider.class, PollForDecisionTaskResponse.class, Duration.class);
+      constructor.setAccessible(true);
+
+      when(mockedHelper.getTask()).thenReturn(task);
+      when(mockContext.getDomain()).thenReturn(DOMAIN);
+
+      // Create an instance of the outer class
+      ReplayDecider outerInstance =
+          new ReplayDecider(
+              mockService,
+              DOMAIN,
+              new WorkflowType().setName("testWorkflow"),
+              null,
+              mockedHelper,
+              SingleWorkerOptions.newBuilder()
+                  .setMetricsScope(WorkflowClientOptions.defaultInstance().getMetricsScope())
+                  .build(),
+              null);
+
+      // Create the instance
+      iterator = constructor.newInstance(outerInstance, task, Duration.ofSeconds(10));
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new RuntimeException("Failed to set up test: " + e.getMessage(), e);
+    }
+  }
+
+  // Helper method to find the inner class
+  private Class<?> findDecisionTaskWithHistoryIteratorImplClass() {
+    for (Class<?> declaredClass : ReplayDecider.class.getDeclaredClasses()) {
+      if (declaredClass.getSimpleName().equals("DecisionTaskWithHistoryIteratorImpl")) {
+        return declaredClass;
+      }
+    }
+    throw new RuntimeException("Could not find DecisionTaskWithHistoryIteratorImpl inner class");
+  }
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    setupDecisionTaskWithHistoryIteratorImpl();
+  }
+
+  @Test
+  public void testGetHistoryWithSinglePageOfEvents()
+      throws TException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    // Arrange
+    List<HistoryEvent> events = Arrays.asList(createMockHistoryEvent(2), createMockHistoryEvent(3));
+    History mockHistory = new History().setEvents(events);
+    when(mockService.GetWorkflowExecutionHistory(
+            new GetWorkflowExecutionHistoryRequest()
+                .setDomain(DOMAIN)
+                .setNextPageToken(START_PAGE_TOKEN.getBytes())
+                .setExecution(WORKFLOW_EXECUTION)
+                .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
+        .thenReturn(new GetWorkflowExecutionHistoryResponse().setHistory(mockHistory));
+
+    // Act & Assert
+    Method wrapperMethod = iterator.getClass().getMethod("getHistory");
+
+    Object result = wrapperMethod.invoke(iterator);
+    Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
+    assertTrue(historyIterator.hasNext());
+    assertEquals(START_EVENT.getEventId(), historyIterator.next().getEventId());
+    assertTrue(historyIterator.hasNext());
+    assertEquals(events.get(0).getEventId(), historyIterator.next().getEventId());
+    assertTrue(historyIterator.hasNext());
+    assertEquals(events.get(1).getEventId(), historyIterator.next().getEventId());
+    assertFalse(historyIterator.hasNext());
+  }
+
+  @Test
+  public void testGetHistoryWithMultiplePages()
+      throws TException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    // First page events
+    List<HistoryEvent> firstPageEvents =
+        Arrays.asList(createMockHistoryEvent(1), createMockHistoryEvent(2));
+    History firstHistory = new History().setEvents(firstPageEvents);
+    String firstPageToken = "firstPageToken";
+    when(mockService.GetWorkflowExecutionHistory(
+            eq(
+                new GetWorkflowExecutionHistoryRequest()
+                    .setDomain(DOMAIN)
+                    .setNextPageToken(START_PAGE_TOKEN.getBytes())
+                    .setExecution(WORKFLOW_EXECUTION)
+                    .setMaximumPageSize(MAXIMUM_PAGE_SIZE))))
+        .thenReturn(
+            new GetWorkflowExecutionHistoryResponse()
+                .setHistory(firstHistory)
+                .setNextPageToken(firstPageToken.getBytes()));
+
+    // Second page events
+    List<HistoryEvent> secondPageEvents =
+        Arrays.asList(createMockHistoryEvent(3), createMockHistoryEvent(4));
+    History secondHistory = new History().setEvents(secondPageEvents);
+    when(mockService.GetWorkflowExecutionHistory(
+            eq(
+                new GetWorkflowExecutionHistoryRequest()
+                    .setDomain(DOMAIN)
+                    .setNextPageToken(firstPageToken.getBytes())
+                    .setExecution(WORKFLOW_EXECUTION)
+                    .setMaximumPageSize(MAXIMUM_PAGE_SIZE))))
+        .thenReturn(new GetWorkflowExecutionHistoryResponse().setHistory(secondHistory));
+
+    // Act & Assert
+    Method wrapperMethod = iterator.getClass().getMethod("getHistory");
+
+    Object result = wrapperMethod.invoke(iterator);
+    Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
+    // Check first page events
+    assertEquals(START_EVENT.getEventId(), historyIterator.next().getEventId());
+    assertEquals(firstPageEvents.get(0).getEventId(), historyIterator.next().getEventId());
+    assertEquals(firstPageEvents.get(1).getEventId(), historyIterator.next().getEventId());
+
+    // Check second page events
+    assertEquals(secondPageEvents.get(0).getEventId(), historyIterator.next().getEventId());
+    assertEquals(secondPageEvents.get(1).getEventId(), historyIterator.next().getEventId());
+
+    assertFalse(historyIterator.hasNext());
+  }
+
+  @Test(expected = Error.class)
+  public void testGetHistoryWithTimeout()
+      throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, TException {
+    when(mockService.GetWorkflowExecutionHistory(
+            new GetWorkflowExecutionHistoryRequest()
+                .setDomain(DOMAIN)
+                .setNextPageToken(START_PAGE_TOKEN.getBytes())
+                .setExecution(WORKFLOW_EXECUTION)
+                .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
+        .thenThrow(new TException());
+
+    // Act & Assert
+    Method wrapperMethod = iterator.getClass().getMethod("getHistory");
+
+    Object result = wrapperMethod.invoke(iterator);
+    Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
+    historyIterator.next();
+
+    historyIterator.next(); // This should throw an Error due to timeout
+  }
+
+  @Test(expected = Error.class)
+  public void testEmptyHistory()
+      throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, TException {
+    when(mockService.GetWorkflowExecutionHistory(
+            new GetWorkflowExecutionHistoryRequest()
+                .setDomain(DOMAIN)
+                .setNextPageToken(START_PAGE_TOKEN.getBytes())
+                .setExecution(WORKFLOW_EXECUTION)
+                .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
+        .thenReturn(
+            new GetWorkflowExecutionHistoryResponse()
+                .setHistory(new History().setEvents(new ArrayList<>())));
+
+    // Act & Assert
+    Method wrapperMethod = iterator.getClass().getMethod("getHistory");
+
+    Object result = wrapperMethod.invoke(iterator);
+    Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
+    historyIterator.next();
+
+    historyIterator.next(); // This should throw an Error due to timeout
+  }
+
+  // Helper method to create mock HistoryEvent
+  private HistoryEvent createMockHistoryEvent(int eventId) {
+    return new HistoryEvent().setEventId(eventId);
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/replay/ReplaceDeciderDecisionTaskWithHistoryIteratorTest.java
+++ b/src/test/java/com/uber/cadence/internal/replay/ReplaceDeciderDecisionTaskWithHistoryIteratorTest.java
@@ -24,11 +24,13 @@ import com.uber.cadence.*;
 import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.internal.worker.SingleWorkerOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.*;
+
 import org.apache.thrift.TException;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,207 +38,210 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class ReplaceDeciderDecisionTaskWithHistoryIteratorTest {
-  @Mock private IWorkflowService mockService;
+    @Mock
+    private IWorkflowService mockService;
 
-  @Mock private DecisionContextImpl mockContext;
+    @Mock
+    private DecisionContextImpl mockContext;
 
-  @Mock private DecisionsHelper mockedHelper;
+    @Mock
+    private DecisionsHelper mockedHelper;
 
-  private static final int MAXIMUM_PAGE_SIZE = 10000;
-  private final String WORKFLOW_ID = "testWorkflowId";
-  private final String RUN_ID = "testRunId";
-  private final String DOMAIN = "testDomain";
-  private final String START_PAGE_TOKEN = "testPageToken";
-  private final WorkflowExecution WORKFLOW_EXECUTION =
-      new WorkflowExecution().setWorkflowId(WORKFLOW_ID).setRunId(RUN_ID);
-  private final HistoryEvent START_EVENT =
-      new HistoryEvent()
-          .setWorkflowExecutionStartedEventAttributes(new WorkflowExecutionStartedEventAttributes())
-          .setEventId(1);
-  private final History HISTORY = new History().setEvents(Collections.singletonList(START_EVENT));
-  private final PollForDecisionTaskResponse task =
-      new PollForDecisionTaskResponse()
-          .setWorkflowExecution(WORKFLOW_EXECUTION)
-          .setHistory(HISTORY)
-          .setNextPageToken(START_PAGE_TOKEN.getBytes());
+    private static final int MAXIMUM_PAGE_SIZE = 10000;
+    private final String WORKFLOW_ID = "testWorkflowId";
+    private final String RUN_ID = "testRunId";
+    private final String DOMAIN = "testDomain";
+    private final String START_PAGE_TOKEN = "testPageToken";
+    private final WorkflowExecution WORKFLOW_EXECUTION =
+            new WorkflowExecution().setWorkflowId(WORKFLOW_ID).setRunId(RUN_ID);
+    private final HistoryEvent START_EVENT =
+            new HistoryEvent()
+                    .setWorkflowExecutionStartedEventAttributes(new WorkflowExecutionStartedEventAttributes())
+                    .setEventId(1);
+    private final History HISTORY = new History().setEvents(Collections.singletonList(START_EVENT));
+    private final PollForDecisionTaskResponse task =
+            new PollForDecisionTaskResponse()
+                    .setWorkflowExecution(WORKFLOW_EXECUTION)
+                    .setHistory(HISTORY)
+                    .setNextPageToken(START_PAGE_TOKEN.getBytes());
 
-  private Object iterator;
+    private Object iterator;
 
-  private void setupDecisionTaskWithHistoryIteratorImpl() {
-    try {
-      // Find the inner class first
-      Class<?> innerClass = findDecisionTaskWithHistoryIteratorImplClass();
+    private void setupDecisionTaskWithHistoryIteratorImpl() {
+        try {
+            // Find the inner class first
+            Class<?> innerClass = findDecisionTaskWithHistoryIteratorImplClass();
 
-      // Get the constructor with the specific parameter types
-      Constructor<?> constructor =
-          innerClass.getDeclaredConstructor(
-              ReplayDecider.class, PollForDecisionTaskResponse.class, Duration.class);
-      constructor.setAccessible(true);
+            // Get the constructor with the specific parameter types
+            Constructor<?> constructor =
+                    innerClass.getDeclaredConstructor(
+                            ReplayDecider.class, PollForDecisionTaskResponse.class, Duration.class);
+            constructor.setAccessible(true);
 
-      when(mockedHelper.getTask()).thenReturn(task);
-      when(mockContext.getDomain()).thenReturn(DOMAIN);
+            when(mockedHelper.getTask()).thenReturn(task);
+            when(mockContext.getDomain()).thenReturn(DOMAIN);
 
-      // Create an instance of the outer class
-      ReplayDecider outerInstance =
-          new ReplayDecider(
-              mockService,
-              DOMAIN,
-              new WorkflowType().setName("testWorkflow"),
-              null,
-              mockedHelper,
-              SingleWorkerOptions.newBuilder()
-                  .setMetricsScope(WorkflowClientOptions.defaultInstance().getMetricsScope())
-                  .build(),
-              null);
+            // Create an instance of the outer class
+            ReplayDecider outerInstance =
+                    new ReplayDecider(
+                            mockService,
+                            DOMAIN,
+                            new WorkflowType().setName("testWorkflow"),
+                            null,
+                            mockedHelper,
+                            SingleWorkerOptions.newBuilder()
+                                    .setMetricsScope(WorkflowClientOptions.defaultInstance().getMetricsScope())
+                                    .build(),
+                            null);
 
-      // Create the instance
-      iterator = constructor.newInstance(outerInstance, task, Duration.ofSeconds(10));
-    } catch (Exception e) {
-      e.printStackTrace();
-      throw new RuntimeException("Failed to set up test: " + e.getMessage(), e);
+            // Create the instance
+            iterator = constructor.newInstance(outerInstance, task, Duration.ofSeconds(10));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Failed to set up test: " + e.getMessage(), e);
+        }
     }
-  }
 
-  // Helper method to find the inner class
-  private Class<?> findDecisionTaskWithHistoryIteratorImplClass() {
-    for (Class<?> declaredClass : ReplayDecider.class.getDeclaredClasses()) {
-      if (declaredClass.getSimpleName().equals("DecisionTaskWithHistoryIteratorImpl")) {
-        return declaredClass;
-      }
+    // Helper method to find the inner class
+    private Class<?> findDecisionTaskWithHistoryIteratorImplClass() {
+        for (Class<?> declaredClass : ReplayDecider.class.getDeclaredClasses()) {
+            if (declaredClass.getSimpleName().equals("DecisionTaskWithHistoryIteratorImpl")) {
+                return declaredClass;
+            }
+        }
+        throw new RuntimeException("Could not find DecisionTaskWithHistoryIteratorImpl inner class");
     }
-    throw new RuntimeException("Could not find DecisionTaskWithHistoryIteratorImpl inner class");
-  }
 
-  @Before
-  public void setUp() {
-    MockitoAnnotations.openMocks(this);
-    setupDecisionTaskWithHistoryIteratorImpl();
-  }
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        setupDecisionTaskWithHistoryIteratorImpl();
+    }
 
-  @Test
-  public void testGetHistoryWithSinglePageOfEvents()
-      throws TException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    // Arrange
-    List<HistoryEvent> events = Arrays.asList(createMockHistoryEvent(2), createMockHistoryEvent(3));
-    History mockHistory = new History().setEvents(events);
-    when(mockService.GetWorkflowExecutionHistory(
-            new GetWorkflowExecutionHistoryRequest()
-                .setDomain(DOMAIN)
-                .setNextPageToken(START_PAGE_TOKEN.getBytes())
-                .setExecution(WORKFLOW_EXECUTION)
-                .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
-        .thenReturn(new GetWorkflowExecutionHistoryResponse().setHistory(mockHistory));
-
-    // Act & Assert
-    Method wrapperMethod = iterator.getClass().getMethod("getHistory");
-
-    Object result = wrapperMethod.invoke(iterator);
-    Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
-    assertTrue(historyIterator.hasNext());
-    assertEquals(START_EVENT.getEventId(), historyIterator.next().getEventId());
-    assertTrue(historyIterator.hasNext());
-    assertEquals(events.get(0).getEventId(), historyIterator.next().getEventId());
-    assertTrue(historyIterator.hasNext());
-    assertEquals(events.get(1).getEventId(), historyIterator.next().getEventId());
-    assertFalse(historyIterator.hasNext());
-  }
-
-  @Test
-  public void testGetHistoryWithMultiplePages()
-      throws TException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    // First page events
-    List<HistoryEvent> firstPageEvents =
-        Arrays.asList(createMockHistoryEvent(1), createMockHistoryEvent(2));
-    History firstHistory = new History().setEvents(firstPageEvents);
-    String firstPageToken = "firstPageToken";
-    when(mockService.GetWorkflowExecutionHistory(
-            eq(
+    @Test
+    public void testGetHistoryWithSinglePageOfEvents()
+            throws TException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        // Arrange
+        List<HistoryEvent> events = Arrays.asList(createMockHistoryEvent(2), createMockHistoryEvent(3));
+        History mockHistory = new History().setEvents(events);
+        when(mockService.GetWorkflowExecutionHistory(
                 new GetWorkflowExecutionHistoryRequest()
-                    .setDomain(DOMAIN)
-                    .setNextPageToken(START_PAGE_TOKEN.getBytes())
-                    .setExecution(WORKFLOW_EXECUTION)
-                    .setMaximumPageSize(MAXIMUM_PAGE_SIZE))))
-        .thenReturn(
-            new GetWorkflowExecutionHistoryResponse()
-                .setHistory(firstHistory)
-                .setNextPageToken(firstPageToken.getBytes()));
+                        .setDomain(DOMAIN)
+                        .setNextPageToken(START_PAGE_TOKEN.getBytes())
+                        .setExecution(WORKFLOW_EXECUTION)
+                        .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
+                .thenReturn(new GetWorkflowExecutionHistoryResponse().setHistory(mockHistory));
 
-    // Second page events
-    List<HistoryEvent> secondPageEvents =
-        Arrays.asList(createMockHistoryEvent(3), createMockHistoryEvent(4));
-    History secondHistory = new History().setEvents(secondPageEvents);
-    when(mockService.GetWorkflowExecutionHistory(
-            eq(
+        // Act & Assert
+        Method wrapperMethod = iterator.getClass().getMethod("getHistory");
+
+        Object result = wrapperMethod.invoke(iterator);
+        Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
+        assertTrue(historyIterator.hasNext());
+        assertEquals(START_EVENT.getEventId(), historyIterator.next().getEventId());
+        assertTrue(historyIterator.hasNext());
+        assertEquals(events.get(0).getEventId(), historyIterator.next().getEventId());
+        assertTrue(historyIterator.hasNext());
+        assertEquals(events.get(1).getEventId(), historyIterator.next().getEventId());
+        assertFalse(historyIterator.hasNext());
+    }
+
+    @Test
+    public void testGetHistoryWithMultiplePages()
+            throws TException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        // First page events
+        List<HistoryEvent> firstPageEvents =
+                Arrays.asList(createMockHistoryEvent(1), createMockHistoryEvent(2));
+        History firstHistory = new History().setEvents(firstPageEvents);
+        String firstPageToken = "firstPageToken";
+        when(mockService.GetWorkflowExecutionHistory(
+                eq(
+                        new GetWorkflowExecutionHistoryRequest()
+                                .setDomain(DOMAIN)
+                                .setNextPageToken(START_PAGE_TOKEN.getBytes())
+                                .setExecution(WORKFLOW_EXECUTION)
+                                .setMaximumPageSize(MAXIMUM_PAGE_SIZE))))
+                .thenReturn(
+                        new GetWorkflowExecutionHistoryResponse()
+                                .setHistory(firstHistory)
+                                .setNextPageToken(firstPageToken.getBytes()));
+
+        // Second page events
+        List<HistoryEvent> secondPageEvents =
+                Arrays.asList(createMockHistoryEvent(3), createMockHistoryEvent(4));
+        History secondHistory = new History().setEvents(secondPageEvents);
+        when(mockService.GetWorkflowExecutionHistory(
+                eq(
+                        new GetWorkflowExecutionHistoryRequest()
+                                .setDomain(DOMAIN)
+                                .setNextPageToken(firstPageToken.getBytes())
+                                .setExecution(WORKFLOW_EXECUTION)
+                                .setMaximumPageSize(MAXIMUM_PAGE_SIZE))))
+                .thenReturn(new GetWorkflowExecutionHistoryResponse().setHistory(secondHistory));
+
+        // Act & Assert
+        Method wrapperMethod = iterator.getClass().getMethod("getHistory");
+
+        Object result = wrapperMethod.invoke(iterator);
+        Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
+        // Check first page events
+        assertEquals(START_EVENT.getEventId(), historyIterator.next().getEventId());
+        assertEquals(firstPageEvents.get(0).getEventId(), historyIterator.next().getEventId());
+        assertEquals(firstPageEvents.get(1).getEventId(), historyIterator.next().getEventId());
+
+        // Check second page events
+        assertEquals(secondPageEvents.get(0).getEventId(), historyIterator.next().getEventId());
+        assertEquals(secondPageEvents.get(1).getEventId(), historyIterator.next().getEventId());
+
+        assertFalse(historyIterator.hasNext());
+    }
+
+    @Test(expected = Error.class)
+    public void testGetHistoryFailure()
+            throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, TException {
+        when(mockService.GetWorkflowExecutionHistory(
                 new GetWorkflowExecutionHistoryRequest()
-                    .setDomain(DOMAIN)
-                    .setNextPageToken(firstPageToken.getBytes())
-                    .setExecution(WORKFLOW_EXECUTION)
-                    .setMaximumPageSize(MAXIMUM_PAGE_SIZE))))
-        .thenReturn(new GetWorkflowExecutionHistoryResponse().setHistory(secondHistory));
+                        .setDomain(DOMAIN)
+                        .setNextPageToken(START_PAGE_TOKEN.getBytes())
+                        .setExecution(WORKFLOW_EXECUTION)
+                        .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
+                .thenThrow(new TException());
 
-    // Act & Assert
-    Method wrapperMethod = iterator.getClass().getMethod("getHistory");
+        // Act & Assert
+        Method wrapperMethod = iterator.getClass().getMethod("getHistory");
 
-    Object result = wrapperMethod.invoke(iterator);
-    Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
-    // Check first page events
-    assertEquals(START_EVENT.getEventId(), historyIterator.next().getEventId());
-    assertEquals(firstPageEvents.get(0).getEventId(), historyIterator.next().getEventId());
-    assertEquals(firstPageEvents.get(1).getEventId(), historyIterator.next().getEventId());
+        Object result = wrapperMethod.invoke(iterator);
+        Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
+        historyIterator.next();
 
-    // Check second page events
-    assertEquals(secondPageEvents.get(0).getEventId(), historyIterator.next().getEventId());
-    assertEquals(secondPageEvents.get(1).getEventId(), historyIterator.next().getEventId());
+        historyIterator.next(); // This should throw an Error due to timeout
+    }
 
-    assertFalse(historyIterator.hasNext());
-  }
+    @Test(expected = Error.class)
+    public void testEmptyHistory()
+            throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, TException {
+        when(mockService.GetWorkflowExecutionHistory(
+                new GetWorkflowExecutionHistoryRequest()
+                        .setDomain(DOMAIN)
+                        .setNextPageToken(START_PAGE_TOKEN.getBytes())
+                        .setExecution(WORKFLOW_EXECUTION)
+                        .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
+                .thenReturn(
+                        new GetWorkflowExecutionHistoryResponse()
+                                .setHistory(new History().setEvents(new ArrayList<>())));
 
-  @Test(expected = Error.class)
-  public void testGetHistoryWithTimeout()
-      throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, TException {
-    when(mockService.GetWorkflowExecutionHistory(
-            new GetWorkflowExecutionHistoryRequest()
-                .setDomain(DOMAIN)
-                .setNextPageToken(START_PAGE_TOKEN.getBytes())
-                .setExecution(WORKFLOW_EXECUTION)
-                .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
-        .thenThrow(new TException());
+        // Act & Assert
+        Method wrapperMethod = iterator.getClass().getMethod("getHistory");
 
-    // Act & Assert
-    Method wrapperMethod = iterator.getClass().getMethod("getHistory");
+        Object result = wrapperMethod.invoke(iterator);
+        Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
+        historyIterator.next();
 
-    Object result = wrapperMethod.invoke(iterator);
-    Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
-    historyIterator.next();
+        historyIterator.next(); // This should throw an Error due to timeout
+    }
 
-    historyIterator.next(); // This should throw an Error due to timeout
-  }
-
-  @Test(expected = Error.class)
-  public void testEmptyHistory()
-      throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, TException {
-    when(mockService.GetWorkflowExecutionHistory(
-            new GetWorkflowExecutionHistoryRequest()
-                .setDomain(DOMAIN)
-                .setNextPageToken(START_PAGE_TOKEN.getBytes())
-                .setExecution(WORKFLOW_EXECUTION)
-                .setMaximumPageSize(MAXIMUM_PAGE_SIZE)))
-        .thenReturn(
-            new GetWorkflowExecutionHistoryResponse()
-                .setHistory(new History().setEvents(new ArrayList<>())));
-
-    // Act & Assert
-    Method wrapperMethod = iterator.getClass().getMethod("getHistory");
-
-    Object result = wrapperMethod.invoke(iterator);
-    Iterator<HistoryEvent> historyIterator = (Iterator<HistoryEvent>) result;
-    historyIterator.next();
-
-    historyIterator.next(); // This should throw an Error due to timeout
-  }
-
-  // Helper method to create mock HistoryEvent
-  private HistoryEvent createMockHistoryEvent(int eventId) {
-    return new HistoryEvent().setEventId(eventId);
-  }
+    // Helper method to create mock HistoryEvent
+    private HistoryEvent createMockHistoryEvent(int eventId) {
+        return new HistoryEvent().setEventId(eventId);
+    }
 }

--- a/src/test/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternalTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternalTest.java
@@ -25,7 +25,6 @@ import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.workflow.Functions;
 import com.uber.cadence.workflow.WorkflowInterceptorBase;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -33,338 +32,327 @@ import java.time.Duration;
 import java.util.*;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class TestActivityEnvironmentInternalTest {
-    @Mock
-    private IWorkflowService mockWorkflowService;
+  @Mock private IWorkflowService mockWorkflowService;
 
-    @Mock
-    private WorkflowInterceptorBase mockNext;
+  @Mock private WorkflowInterceptorBase mockNext;
 
-    private Object testActivityExecutor;
+  private Object testActivityExecutor;
 
-    private Object testWorkflowServiceWrapper;
+  private Object testWorkflowServiceWrapper;
 
-    // Helper method to find the inner class
-    private Class<?> findTestActivityExecutorClass() {
-        for (Class<?> declaredClass : TestActivityEnvironmentInternal.class.getDeclaredClasses()) {
-            if (declaredClass.getSimpleName().equals("TestActivityExecutor")) {
-                return declaredClass;
-            }
+  // Helper method to find the inner class
+  private Class<?> findTestActivityExecutorClass() {
+    for (Class<?> declaredClass : TestActivityEnvironmentInternal.class.getDeclaredClasses()) {
+      if (declaredClass.getSimpleName().equals("TestActivityExecutor")) {
+        return declaredClass;
+      }
+    }
+    throw new RuntimeException("Could not find TestActivityExecutor inner class");
+  }
+
+  // Helper method to find the inner class
+  private Class<?> findWorkflowServiceWrapperClass() {
+    for (Class<?> declaredClass : TestActivityEnvironmentInternal.class.getDeclaredClasses()) {
+      if (declaredClass.getSimpleName().equals("WorkflowServiceWrapper")) {
+        return declaredClass;
+      }
+    }
+    throw new RuntimeException("Could not find WorkflowServiceWrapper inner class");
+  }
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    setupActivityExecutor();
+
+    setupWorkflowServiceWrapper();
+  }
+
+  private void setupActivityExecutor() {
+    try {
+      // Find the inner class first
+      Class<?> innerClass = findTestActivityExecutorClass();
+
+      // Get the constructor with the specific parameter types
+      Constructor<?> constructor =
+          innerClass.getDeclaredConstructor(
+              TestActivityEnvironmentInternal.class,
+              IWorkflowService.class,
+              WorkflowInterceptorBase.class);
+      constructor.setAccessible(true);
+
+      // Create an instance of the outer class
+      TestActivityEnvironmentInternal outerInstance = mock(TestActivityEnvironmentInternal.class);
+
+      // Create the instance
+      testActivityExecutor = constructor.newInstance(outerInstance, mockWorkflowService, mockNext);
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new RuntimeException("Failed to set up test: " + e.getMessage(), e);
+    }
+  }
+
+  private void setupWorkflowServiceWrapper() {
+    try {
+      // Find the inner class first
+      Class<?> innerClass = findWorkflowServiceWrapperClass();
+
+      // Get the constructor with the specific parameter types
+      Constructor<?> constructor =
+          innerClass.getDeclaredConstructor(
+              TestActivityEnvironmentInternal.class, IWorkflowService.class);
+      constructor.setAccessible(true);
+
+      // Create an instance of the outer class
+      TestActivityEnvironmentInternal outerInstance = mock(TestActivityEnvironmentInternal.class);
+
+      // Create the instance
+      testWorkflowServiceWrapper = constructor.newInstance(outerInstance, mockWorkflowService);
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new RuntimeException("Failed to set up test: " + e.getMessage(), e);
+    }
+  }
+
+  @Test
+  public void testWorkflowServiceWrapperMethodDelegation() throws Exception {
+    // Prepare test cases
+    List<MethodTestCase> testCases = prepareMethodTestCases();
+
+    // Test each method
+    for (MethodTestCase testCase : testCases) {
+      try {
+        // Find the method on the wrapper
+        Method wrapperMethod =
+            testWorkflowServiceWrapper
+                .getClass()
+                .getMethod(testCase.methodName, testCase.parameterTypes);
+
+        // Invoke the method on the wrapper
+        wrapperMethod.invoke(testWorkflowServiceWrapper, testCase.arguments);
+
+        // Generic verification using reflection
+        verifyMethodInvocation(mockWorkflowService, testCase);
+
+      } catch (Exception e) {
+        // Rethrow to fail the test if any unexpected exception occurs
+        throw new AssertionError("Failed to test method: " + testCase.methodName, e);
+      }
+    }
+  }
+
+  @Test
+  public void testAllMethodsThrowUnsupportedOperationException() throws Exception {
+    // Define test cases for different methods
+    MethodTestCase[] methodCases = {
+      // Signature: newRandom()
+      new MethodTestCase("newRandom", new Class<?>[0], new Object[0]),
+
+      // Signature: signalExternalWorkflow(String, WorkflowExecution, String, Object[])
+      new MethodTestCase(
+          "signalExternalWorkflow",
+          new Class<?>[] {String.class, WorkflowExecution.class, String.class, Object[].class},
+          new Object[] {
+            "testSignal", mock(WorkflowExecution.class), "signalName", new Object[] {}
+          }),
+
+      // Signature: signalExternalWorkflow(WorkflowExecution, String, Object[])
+      new MethodTestCase(
+          "signalExternalWorkflow",
+          new Class<?>[] {WorkflowExecution.class, String.class, Object[].class},
+          new Object[] {mock(WorkflowExecution.class), "signalName", new Object[] {}}),
+
+      // Signature: cancelWorkflow(WorkflowExecution)
+      new MethodTestCase(
+          "cancelWorkflow",
+          new Class<?>[] {WorkflowExecution.class},
+          new Object[] {mock(WorkflowExecution.class)}),
+
+      // Signature: sleep(Duration)
+      new MethodTestCase(
+          "sleep", new Class<?>[] {Duration.class}, new Object[] {Duration.ofSeconds(1)}),
+
+      // Signature: await(Duration, String, Supplier)
+      new MethodTestCase(
+          "await",
+          new Class<?>[] {Duration.class, String.class, Supplier.class},
+          new Object[] {Duration.ofSeconds(1), "testReason", (Supplier<?>) () -> true}),
+
+      // Signature: await(String, Supplier)
+      new MethodTestCase(
+          "await",
+          new Class<?>[] {String.class, Supplier.class},
+          new Object[] {"testReason", (Supplier<?>) () -> true}),
+
+      // Signature: newTimer(Duration)
+      new MethodTestCase(
+          "newTimer", new Class<?>[] {Duration.class}, new Object[] {Duration.ofSeconds(1)}),
+
+      // Signature: sideEffect(Class, Type, Functions.Func)
+      new MethodTestCase(
+          "sideEffect",
+          new Class<?>[] {Class.class, Type.class, Functions.Func.class},
+          new Object[] {String.class, String.class, (Functions.Func<String>) () -> "test"}),
+
+      // Signature: mutableSideEffect(String, Class, Type, BiPredicate, Functions.Func)
+      new MethodTestCase(
+          "mutableSideEffect",
+          new Class<?>[] {
+            String.class, Class.class, Type.class, BiPredicate.class, Functions.Func.class
+          },
+          new Object[] {
+            "testId",
+            String.class,
+            String.class,
+            (BiPredicate<String, String>) (a, b) -> false,
+            (Functions.Func<String>) () -> "test"
+          }),
+
+      // Signature: getVersion(String, int, int)
+      new MethodTestCase(
+          "getVersion",
+          new Class<?>[] {String.class, int.class, int.class},
+          new Object[] {"changeId", 0, 1}),
+
+      // Signature: continueAsNew(Optional, Optional, Object[])
+      new MethodTestCase(
+          "continueAsNew",
+          new Class<?>[] {Optional.class, Optional.class, Object[].class},
+          new Object[] {Optional.empty(), Optional.empty(), new Object[] {}}),
+
+      // Signature: registerQuery(String, Type[], Func1)
+      new MethodTestCase(
+          "registerQuery",
+          new Class<?>[] {String.class, Type[].class, Functions.Func1.class},
+          new Object[] {
+            "queryType",
+            new Type[] {String.class},
+            (Functions.Func1<Object[], Object>) args -> "result"
+          }),
+
+      // Signature: randomUUID()
+      new MethodTestCase("randomUUID", new Class<?>[0], new Object[0]),
+
+      // Signature: upsertSearchAttributes(Map)
+      new MethodTestCase(
+          "upsertSearchAttributes",
+          new Class<?>[] {Map.class},
+          new Object[] {java.util.Collections.emptyMap()})
+    };
+
+    // Test each method
+    for (MethodTestCase testCase : methodCases) {
+      try {
+        // Find the method
+        Method method =
+            testActivityExecutor
+                .getClass()
+                .getDeclaredMethod(testCase.methodName, testCase.parameterTypes);
+        method.setAccessible(true);
+
+        // Invoke the method
+        Object result = method.invoke(testActivityExecutor, testCase.arguments);
+
+        // If we get here, the method did not throw UnsupportedOperationException
+        fail("Expected UnsupportedOperationException for method " + testCase.methodName);
+
+      } catch (Exception e) {
+        // Check if the cause is UnsupportedOperationException
+        if (!(e.getCause() instanceof UnsupportedOperationException)) {
+          // If it's not the expected exception, rethrow
+          throw new RuntimeException("Unexpected exception for method " + testCase.methodName, e);
         }
-        throw new RuntimeException("Could not find TestActivityExecutor inner class");
+        // Expected behavior - UnsupportedOperationException was thrown
+        // Continue to next method
+      }
+    }
+  }
+
+  // Helper class to encapsulate method test cases
+  private static class MethodTestCase {
+    String methodName;
+    Class<?>[] parameterTypes;
+    Object[] arguments;
+
+    MethodTestCase(String methodName, Class<?>[] parameterTypes, Object[] arguments) {
+      this.methodName = methodName;
+      this.parameterTypes = parameterTypes;
+      this.arguments = arguments;
+    }
+  }
+
+  /** Generic method to verify method invocation on mock */
+  private void verifyMethodInvocation(Object mockObject, MethodTestCase testCase) throws Exception {
+    // Use Mockito's verify with reflection
+    if (testCase.arguments.length == 0) {
+      // For methods with no arguments
+      verify(mockObject).getClass().getMethod(testCase.methodName).invoke(mockObject);
+    } else {
+      // For methods with arguments
+      Method verifyMethod = org.mockito.Mockito.class.getMethod("verify", Object.class);
+      Object verifiedMock = verifyMethod.invoke(null, mockObject);
+
+      // Invoke the method on the verified mock
+      verifiedMock
+          .getClass()
+          .getMethod(testCase.methodName, testCase.parameterTypes)
+          .invoke(verifiedMock, testCase.arguments);
+    }
+  }
+
+  /** Prepares test cases for all methods in IWorkflowService */
+  private List<MethodTestCase> prepareMethodTestCases() throws Exception {
+    List<MethodTestCase> testCases = new ArrayList<>();
+
+    // You can add more methods here as needed
+    // Dynamically discover and add more methods from IWorkflowService if required
+    Method[] allMethods = IWorkflowService.class.getMethods();
+    for (Method method : allMethods) {
+      testCases.add(createDefaultMethodTestCase(method));
+    }
+    return testCases;
+  }
+
+  /** Creates a default MethodTestCase for a given method */
+  private MethodTestCase createDefaultMethodTestCase(Method method) throws Exception {
+    Class<?>[] parameterTypes = method.getParameterTypes();
+    Object[] arguments = new Object[parameterTypes.length];
+
+    for (int i = 0; i < parameterTypes.length; i++) {
+      arguments[i] = createDefaultArgument(parameterTypes[i]);
     }
 
-    // Helper method to find the inner class
-    private Class<?> findWorkflowServiceWrapperClass() {
-        for (Class<?> declaredClass : TestActivityEnvironmentInternal.class.getDeclaredClasses()) {
-            if (declaredClass.getSimpleName().equals("WorkflowServiceWrapper")) {
-                return declaredClass;
-            }
-        }
-        throw new RuntimeException("Could not find WorkflowServiceWrapper inner class");
+    return new MethodTestCase(method.getName(), parameterTypes, arguments);
+  }
+
+  /** Creates a default argument for different parameter types */
+  private Object createDefaultArgument(Class<?> type) throws Exception {
+    if (type.isPrimitive()) {
+      if (type == boolean.class) return false;
+      if (type == char.class) return '\u0000';
+      if (type == byte.class) return (byte) 0;
+      if (type == short.class) return (short) 0;
+      if (type == int.class) return 0;
+      if (type == long.class) return 0L;
+      if (type == float.class) return 0.0f;
+      if (type == double.class) return 0.0d;
     }
 
-    @Before
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
-
-        setupActivityExecutor();
-
-        setupWorkflowServiceWrapper();
+    // For non-primitive types, try to create an empty instance
+    if (type.getConstructors().length > 0
+        && Arrays.stream(type.getConstructors())
+            .anyMatch(constructor -> constructor.getParameterCount() == 0)) {
+      return type.getDeclaredConstructor().newInstance();
     }
 
-    private void setupActivityExecutor() {
-        try {
-            // Find the inner class first
-            Class<?> innerClass = findTestActivityExecutorClass();
-
-            // Get the constructor with the specific parameter types
-            Constructor<?> constructor =
-                    innerClass.getDeclaredConstructor(
-                            TestActivityEnvironmentInternal.class,
-                            IWorkflowService.class,
-                            WorkflowInterceptorBase.class);
-            constructor.setAccessible(true);
-
-            // Create an instance of the outer class
-            TestActivityEnvironmentInternal outerInstance = mock(TestActivityEnvironmentInternal.class);
-
-            // Create the instance
-            testActivityExecutor = constructor.newInstance(outerInstance, mockWorkflowService, mockNext);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException("Failed to set up test: " + e.getMessage(), e);
-        }
-    }
-
-    private void setupWorkflowServiceWrapper() {
-        try {
-            // Find the inner class first
-            Class<?> innerClass = findWorkflowServiceWrapperClass();
-
-            // Get the constructor with the specific parameter types
-            Constructor<?> constructor =
-                    innerClass.getDeclaredConstructor(
-                            TestActivityEnvironmentInternal.class, IWorkflowService.class);
-            constructor.setAccessible(true);
-
-            // Create an instance of the outer class
-            TestActivityEnvironmentInternal outerInstance = mock(TestActivityEnvironmentInternal.class);
-
-            // Create the instance
-            testWorkflowServiceWrapper = constructor.newInstance(outerInstance, mockWorkflowService);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException("Failed to set up test: " + e.getMessage(), e);
-        }
-    }
-
-    @Test
-    public void testWorkflowServiceWrapperMethodDelegation() throws Exception {
-        // Prepare test cases
-        List<MethodTestCase> testCases = prepareMethodTestCases();
-
-        // Test each method
-        for (MethodTestCase testCase : testCases) {
-            try {
-                // Find the method on the wrapper
-                Method wrapperMethod =
-                        testWorkflowServiceWrapper
-                                .getClass()
-                                .getMethod(testCase.methodName, testCase.parameterTypes);
-
-                // Invoke the method on the wrapper
-                wrapperMethod.invoke(testWorkflowServiceWrapper, testCase.arguments);
-
-                // Generic verification using reflection
-                verifyMethodInvocation(mockWorkflowService, testCase);
-
-            } catch (Exception e) {
-                // Rethrow to fail the test if any unexpected exception occurs
-                throw new AssertionError("Failed to test method: " + testCase.methodName, e);
-            }
-        }
-    }
-
-    @Test
-    public void testAllMethodsThrowUnsupportedOperationException() throws Exception {
-        // Define test cases for different methods
-        MethodTestCase[] methodCases = {
-                // Signature: newRandom()
-                new MethodTestCase("newRandom", new Class<?>[0], new Object[0]),
-
-                // Signature: signalExternalWorkflow(String, WorkflowExecution, String, Object[])
-                new MethodTestCase(
-                        "signalExternalWorkflow",
-                        new Class<?>[]{String.class, WorkflowExecution.class, String.class, Object[].class},
-                        new Object[]{
-                                "testSignal", mock(WorkflowExecution.class), "signalName", new Object[]{}
-                        }),
-
-                // Signature: signalExternalWorkflow(WorkflowExecution, String, Object[])
-                new MethodTestCase(
-                        "signalExternalWorkflow",
-                        new Class<?>[]{WorkflowExecution.class, String.class, Object[].class},
-                        new Object[]{mock(WorkflowExecution.class), "signalName", new Object[]{}}),
-
-                // Signature: cancelWorkflow(WorkflowExecution)
-                new MethodTestCase(
-                        "cancelWorkflow",
-                        new Class<?>[]{WorkflowExecution.class},
-                        new Object[]{mock(WorkflowExecution.class)}),
-
-                // Signature: sleep(Duration)
-                new MethodTestCase(
-                        "sleep", new Class<?>[]{Duration.class}, new Object[]{Duration.ofSeconds(1)}),
-
-                // Signature: await(Duration, String, Supplier)
-                new MethodTestCase(
-                        "await",
-                        new Class<?>[]{Duration.class, String.class, Supplier.class},
-                        new Object[]{Duration.ofSeconds(1), "testReason", (Supplier<?>) () -> true}),
-
-                // Signature: await(String, Supplier)
-                new MethodTestCase(
-                        "await",
-                        new Class<?>[]{String.class, Supplier.class},
-                        new Object[]{"testReason", (Supplier<?>) () -> true}),
-
-                // Signature: newTimer(Duration)
-                new MethodTestCase(
-                        "newTimer", new Class<?>[]{Duration.class}, new Object[]{Duration.ofSeconds(1)}),
-
-                // Signature: sideEffect(Class, Type, Functions.Func)
-                new MethodTestCase(
-                        "sideEffect",
-                        new Class<?>[]{Class.class, Type.class, Functions.Func.class},
-                        new Object[]{String.class, String.class, (Functions.Func<String>) () -> "test"}),
-
-                // Signature: mutableSideEffect(String, Class, Type, BiPredicate, Functions.Func)
-                new MethodTestCase(
-                        "mutableSideEffect",
-                        new Class<?>[]{
-                                String.class, Class.class, Type.class, BiPredicate.class, Functions.Func.class
-                        },
-                        new Object[]{
-                                "testId",
-                                String.class,
-                                String.class,
-                                (BiPredicate<String, String>) (a, b) -> false,
-                                (Functions.Func<String>) () -> "test"
-                        }),
-
-                // Signature: getVersion(String, int, int)
-                new MethodTestCase(
-                        "getVersion",
-                        new Class<?>[]{String.class, int.class, int.class},
-                        new Object[]{"changeId", 0, 1}),
-
-                // Signature: continueAsNew(Optional, Optional, Object[])
-                new MethodTestCase(
-                        "continueAsNew",
-                        new Class<?>[]{Optional.class, Optional.class, Object[].class},
-                        new Object[]{Optional.empty(), Optional.empty(), new Object[]{}}),
-
-                // Signature: registerQuery(String, Type[], Func1)
-                new MethodTestCase(
-                        "registerQuery",
-                        new Class<?>[]{String.class, Type[].class, Functions.Func1.class},
-                        new Object[]{
-                                "queryType",
-                                new Type[]{String.class},
-                                (Functions.Func1<Object[], Object>) args -> "result"
-                        }),
-
-                // Signature: randomUUID()
-                new MethodTestCase("randomUUID", new Class<?>[0], new Object[0]),
-
-                // Signature: upsertSearchAttributes(Map)
-                new MethodTestCase(
-                        "upsertSearchAttributes",
-                        new Class<?>[]{Map.class},
-                        new Object[]{java.util.Collections.emptyMap()})
-        };
-
-        // Test each method
-        for (MethodTestCase testCase : methodCases) {
-            try {
-                // Find the method
-                Method method =
-                        testActivityExecutor
-                                .getClass()
-                                .getDeclaredMethod(testCase.methodName, testCase.parameterTypes);
-                method.setAccessible(true);
-
-                // Invoke the method
-                Object result = method.invoke(testActivityExecutor, testCase.arguments);
-
-                // If we get here, the method did not throw UnsupportedOperationException
-                fail("Expected UnsupportedOperationException for method " + testCase.methodName);
-
-            } catch (Exception e) {
-                // Check if the cause is UnsupportedOperationException
-                if (!(e.getCause() instanceof UnsupportedOperationException)) {
-                    // If it's not the expected exception, rethrow
-                    throw new RuntimeException("Unexpected exception for method " + testCase.methodName, e);
-                }
-                // Expected behavior - UnsupportedOperationException was thrown
-                // Continue to next method
-            }
-        }
-    }
-
-    // Helper class to encapsulate method test cases
-    private static class MethodTestCase {
-        String methodName;
-        Class<?>[] parameterTypes;
-        Object[] arguments;
-
-        MethodTestCase(String methodName, Class<?>[] parameterTypes, Object[] arguments) {
-            this.methodName = methodName;
-            this.parameterTypes = parameterTypes;
-            this.arguments = arguments;
-        }
-    }
-
-    /**
-     * Generic method to verify method invocation on mock
-     */
-    private void verifyMethodInvocation(Object mockObject, MethodTestCase testCase) throws Exception {
-        // Use Mockito's verify with reflection
-        if (testCase.arguments.length == 0) {
-            // For methods with no arguments
-            verify(mockObject).getClass().getMethod(testCase.methodName).invoke(mockObject);
-        } else {
-            // For methods with arguments
-            Method verifyMethod = org.mockito.Mockito.class.getMethod("verify", Object.class);
-            Object verifiedMock = verifyMethod.invoke(null, mockObject);
-
-            // Invoke the method on the verified mock
-            verifiedMock
-                    .getClass()
-                    .getMethod(testCase.methodName, testCase.parameterTypes)
-                    .invoke(verifiedMock, testCase.arguments);
-        }
-    }
-
-    /**
-     * Prepares test cases for all methods in IWorkflowService
-     */
-    private List<MethodTestCase> prepareMethodTestCases() throws Exception {
-        List<MethodTestCase> testCases = new ArrayList<>();
-
-        // You can add more methods here as needed
-        // Dynamically discover and add more methods from IWorkflowService if required
-        Method[] allMethods = IWorkflowService.class.getMethods();
-        for (Method method : allMethods) {
-            testCases.add(createDefaultMethodTestCase(method));
-        }
-        return testCases;
-    }
-
-    /**
-     * Creates a default MethodTestCase for a given method
-     */
-    private MethodTestCase createDefaultMethodTestCase(Method method) throws Exception {
-        Class<?>[] parameterTypes = method.getParameterTypes();
-        Object[] arguments = new Object[parameterTypes.length];
-
-        for (int i = 0; i < parameterTypes.length; i++) {
-            arguments[i] = createDefaultArgument(parameterTypes[i]);
-        }
-
-        return new MethodTestCase(method.getName(), parameterTypes, arguments);
-    }
-
-    /**
-     * Creates a default argument for different parameter types
-     */
-    private Object createDefaultArgument(Class<?> type) throws Exception {
-        if (type.isPrimitive()) {
-            if (type == boolean.class) return false;
-            if (type == char.class) return '\u0000';
-            if (type == byte.class) return (byte) 0;
-            if (type == short.class) return (short) 0;
-            if (type == int.class) return 0;
-            if (type == long.class) return 0L;
-            if (type == float.class) return 0.0f;
-            if (type == double.class) return 0.0d;
-        }
-
-        // For non-primitive types, try to create an empty instance
-        if (type.getConstructors().length > 0
-                && Arrays.stream(type.getConstructors())
-                .anyMatch(constructor -> constructor.getParameterCount() == 0)) {
-            return type.getDeclaredConstructor().newInstance();
-        }
-
-        // Fallback for complex types
-        return null;
-    }
+    // Fallback for complex types
+    return null;
+  }
 }

--- a/src/test/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternalTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternalTest.java
@@ -25,6 +25,7 @@ import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.workflow.Functions;
 import com.uber.cadence.workflow.WorkflowInterceptorBase;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -32,325 +33,338 @@ import java.time.Duration;
 import java.util.*;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class TestActivityEnvironmentInternalTest {
-  @Mock private IWorkflowService mockWorkflowService;
+    @Mock
+    private IWorkflowService mockWorkflowService;
 
-  @Mock private WorkflowInterceptorBase mockNext;
+    @Mock
+    private WorkflowInterceptorBase mockNext;
 
-  private Object testActivityExecutor;
+    private Object testActivityExecutor;
 
-  private Object testWorkflowServiceWrapper;
+    private Object testWorkflowServiceWrapper;
 
-  // Helper method to find the inner class
-  private Class<?> findTestActivityExecutorClass() {
-    for (Class<?> declaredClass : TestActivityEnvironmentInternal.class.getDeclaredClasses()) {
-      if (declaredClass.getSimpleName().equals("TestActivityExecutor")) {
-        return declaredClass;
-      }
-    }
-    throw new RuntimeException("Could not find TestActivityExecutor inner class");
-  }
-
-  // Helper method to find the inner class
-  private Class<?> findWorkflowServiceWrapperClass() {
-    for (Class<?> declaredClass : TestActivityEnvironmentInternal.class.getDeclaredClasses()) {
-      if (declaredClass.getSimpleName().equals("WorkflowServiceWrapper")) {
-        return declaredClass;
-      }
-    }
-    throw new RuntimeException("Could not find WorkflowServiceWrapper inner class");
-  }
-
-  @Before
-  public void setUp() {
-    MockitoAnnotations.openMocks(this);
-
-    setupActivityExecutor();
-
-    setupWorkflowServiceWrapper();
-  }
-
-  private void setupActivityExecutor() {
-    try {
-      // Find the inner class first
-      Class<?> innerClass = findTestActivityExecutorClass();
-
-      // Get the constructor with the specific parameter types
-      Constructor<?> constructor =
-          innerClass.getDeclaredConstructor(
-              TestActivityEnvironmentInternal.class,
-              IWorkflowService.class,
-              WorkflowInterceptorBase.class);
-
-      // Create an instance of the outer class
-      TestActivityEnvironmentInternal outerInstance = mock(TestActivityEnvironmentInternal.class);
-
-      // Create the instance
-      testActivityExecutor = constructor.newInstance(outerInstance, mockWorkflowService, mockNext);
-    } catch (Exception e) {
-      e.printStackTrace();
-      throw new RuntimeException("Failed to set up test: " + e.getMessage(), e);
-    }
-  }
-
-  private void setupWorkflowServiceWrapper() {
-    try {
-      // Find the inner class first
-      Class<?> innerClass = findWorkflowServiceWrapperClass();
-
-      // Get the constructor with the specific parameter types
-      Constructor<?> constructor =
-          innerClass.getDeclaredConstructor(
-              TestActivityEnvironmentInternal.class, IWorkflowService.class);
-
-      // Create an instance of the outer class
-      TestActivityEnvironmentInternal outerInstance = mock(TestActivityEnvironmentInternal.class);
-
-      // Create the instance
-      testWorkflowServiceWrapper = constructor.newInstance(outerInstance, mockWorkflowService);
-    } catch (Exception e) {
-      e.printStackTrace();
-      throw new RuntimeException("Failed to set up test: " + e.getMessage(), e);
-    }
-  }
-
-  @Test
-  public void testWorkflowServiceWrapperMethodDelegation() throws Exception {
-    // Prepare test cases
-    List<MethodTestCase> testCases = prepareMethodTestCases();
-
-    // Test each method
-    for (MethodTestCase testCase : testCases) {
-      try {
-        // Find the method on the wrapper
-        Method wrapperMethod =
-            testWorkflowServiceWrapper
-                .getClass()
-                .getMethod(testCase.methodName, testCase.parameterTypes);
-
-        // Invoke the method on the wrapper
-        wrapperMethod.invoke(testWorkflowServiceWrapper, testCase.arguments);
-
-        // Generic verification using reflection
-        verifyMethodInvocation(mockWorkflowService, testCase);
-
-      } catch (Exception e) {
-        // Rethrow to fail the test if any unexpected exception occurs
-        throw new AssertionError("Failed to test method: " + testCase.methodName, e);
-      }
-    }
-  }
-
-  @Test
-  public void testAllMethodsThrowUnsupportedOperationException() throws Exception {
-    // Define test cases for different methods
-    MethodTestCase[] methodCases = {
-      // Signature: newRandom()
-      new MethodTestCase("newRandom", new Class<?>[0], new Object[0]),
-
-      // Signature: signalExternalWorkflow(String, WorkflowExecution, String, Object[])
-      new MethodTestCase(
-          "signalExternalWorkflow",
-          new Class<?>[] {String.class, WorkflowExecution.class, String.class, Object[].class},
-          new Object[] {
-            "testSignal", mock(WorkflowExecution.class), "signalName", new Object[] {}
-          }),
-
-      // Signature: signalExternalWorkflow(WorkflowExecution, String, Object[])
-      new MethodTestCase(
-          "signalExternalWorkflow",
-          new Class<?>[] {WorkflowExecution.class, String.class, Object[].class},
-          new Object[] {mock(WorkflowExecution.class), "signalName", new Object[] {}}),
-
-      // Signature: cancelWorkflow(WorkflowExecution)
-      new MethodTestCase(
-          "cancelWorkflow",
-          new Class<?>[] {WorkflowExecution.class},
-          new Object[] {mock(WorkflowExecution.class)}),
-
-      // Signature: sleep(Duration)
-      new MethodTestCase(
-          "sleep", new Class<?>[] {Duration.class}, new Object[] {Duration.ofSeconds(1)}),
-
-      // Signature: await(Duration, String, Supplier)
-      new MethodTestCase(
-          "await",
-          new Class<?>[] {Duration.class, String.class, Supplier.class},
-          new Object[] {Duration.ofSeconds(1), "testReason", (Supplier<?>) () -> true}),
-
-      // Signature: await(String, Supplier)
-      new MethodTestCase(
-          "await",
-          new Class<?>[] {String.class, Supplier.class},
-          new Object[] {"testReason", (Supplier<?>) () -> true}),
-
-      // Signature: newTimer(Duration)
-      new MethodTestCase(
-          "newTimer", new Class<?>[] {Duration.class}, new Object[] {Duration.ofSeconds(1)}),
-
-      // Signature: sideEffect(Class, Type, Functions.Func)
-      new MethodTestCase(
-          "sideEffect",
-          new Class<?>[] {Class.class, Type.class, Functions.Func.class},
-          new Object[] {String.class, String.class, (Functions.Func<String>) () -> "test"}),
-
-      // Signature: mutableSideEffect(String, Class, Type, BiPredicate, Functions.Func)
-      new MethodTestCase(
-          "mutableSideEffect",
-          new Class<?>[] {
-            String.class, Class.class, Type.class, BiPredicate.class, Functions.Func.class
-          },
-          new Object[] {
-            "testId",
-            String.class,
-            String.class,
-            (BiPredicate<String, String>) (a, b) -> false,
-            (Functions.Func<String>) () -> "test"
-          }),
-
-      // Signature: getVersion(String, int, int)
-      new MethodTestCase(
-          "getVersion",
-          new Class<?>[] {String.class, int.class, int.class},
-          new Object[] {"changeId", 0, 1}),
-
-      // Signature: continueAsNew(Optional, Optional, Object[])
-      new MethodTestCase(
-          "continueAsNew",
-          new Class<?>[] {Optional.class, Optional.class, Object[].class},
-          new Object[] {Optional.empty(), Optional.empty(), new Object[] {}}),
-
-      // Signature: registerQuery(String, Type[], Func1)
-      new MethodTestCase(
-          "registerQuery",
-          new Class<?>[] {String.class, Type[].class, Functions.Func1.class},
-          new Object[] {
-            "queryType",
-            new Type[] {String.class},
-            (Functions.Func1<Object[], Object>) args -> "result"
-          }),
-
-      // Signature: randomUUID()
-      new MethodTestCase("randomUUID", new Class<?>[0], new Object[0]),
-
-      // Signature: upsertSearchAttributes(Map)
-      new MethodTestCase(
-          "upsertSearchAttributes",
-          new Class<?>[] {Map.class},
-          new Object[] {java.util.Collections.emptyMap()})
-    };
-
-    // Test each method
-    for (MethodTestCase testCase : methodCases) {
-      try {
-        // Find the method
-        Method method =
-            testActivityExecutor
-                .getClass()
-                .getDeclaredMethod(testCase.methodName, testCase.parameterTypes);
-        method.setAccessible(true);
-
-        // Invoke the method
-        Object result = method.invoke(testActivityExecutor, testCase.arguments);
-
-        // If we get here, the method did not throw UnsupportedOperationException
-        fail("Expected UnsupportedOperationException for method " + testCase.methodName);
-
-      } catch (Exception e) {
-        // Check if the cause is UnsupportedOperationException
-        if (!(e.getCause() instanceof UnsupportedOperationException)) {
-          // If it's not the expected exception, rethrow
-          throw new RuntimeException("Unexpected exception for method " + testCase.methodName, e);
+    // Helper method to find the inner class
+    private Class<?> findTestActivityExecutorClass() {
+        for (Class<?> declaredClass : TestActivityEnvironmentInternal.class.getDeclaredClasses()) {
+            if (declaredClass.getSimpleName().equals("TestActivityExecutor")) {
+                return declaredClass;
+            }
         }
-        // Expected behavior - UnsupportedOperationException was thrown
-        // Continue to next method
-      }
-    }
-  }
-
-  // Helper class to encapsulate method test cases
-  private static class MethodTestCase {
-    String methodName;
-    Class<?>[] parameterTypes;
-    Object[] arguments;
-
-    MethodTestCase(String methodName, Class<?>[] parameterTypes, Object[] arguments) {
-      this.methodName = methodName;
-      this.parameterTypes = parameterTypes;
-      this.arguments = arguments;
-    }
-  }
-
-  /** Generic method to verify method invocation on mock */
-  private void verifyMethodInvocation(Object mockObject, MethodTestCase testCase) throws Exception {
-    // Use Mockito's verify with reflection
-    if (testCase.arguments.length == 0) {
-      // For methods with no arguments
-      verify(mockObject).getClass().getMethod(testCase.methodName).invoke(mockObject);
-    } else {
-      // For methods with arguments
-      Method verifyMethod = org.mockito.Mockito.class.getMethod("verify", Object.class);
-      Object verifiedMock = verifyMethod.invoke(null, mockObject);
-
-      // Invoke the method on the verified mock
-      verifiedMock
-          .getClass()
-          .getMethod(testCase.methodName, testCase.parameterTypes)
-          .invoke(verifiedMock, testCase.arguments);
-    }
-  }
-
-  /** Prepares test cases for all methods in IWorkflowService */
-  private List<MethodTestCase> prepareMethodTestCases() throws Exception {
-    List<MethodTestCase> testCases = new ArrayList<>();
-
-    // You can add more methods here as needed
-    // Dynamically discover and add more methods from IWorkflowService if required
-    Method[] allMethods = IWorkflowService.class.getMethods();
-    for (Method method : allMethods) {
-      testCases.add(createDefaultMethodTestCase(method));
-    }
-    return testCases;
-  }
-
-  /** Creates a default MethodTestCase for a given method */
-  private MethodTestCase createDefaultMethodTestCase(Method method) throws Exception {
-    Class<?>[] parameterTypes = method.getParameterTypes();
-    Object[] arguments = new Object[parameterTypes.length];
-
-    for (int i = 0; i < parameterTypes.length; i++) {
-      arguments[i] = createDefaultArgument(parameterTypes[i]);
+        throw new RuntimeException("Could not find TestActivityExecutor inner class");
     }
 
-    return new MethodTestCase(method.getName(), parameterTypes, arguments);
-  }
-
-  /** Creates a default argument for different parameter types */
-  private Object createDefaultArgument(Class<?> type) throws Exception {
-    if (type.isPrimitive()) {
-      if (type == boolean.class) return false;
-      if (type == char.class) return '\u0000';
-      if (type == byte.class) return (byte) 0;
-      if (type == short.class) return (short) 0;
-      if (type == int.class) return 0;
-      if (type == long.class) return 0L;
-      if (type == float.class) return 0.0f;
-      if (type == double.class) return 0.0d;
+    // Helper method to find the inner class
+    private Class<?> findWorkflowServiceWrapperClass() {
+        for (Class<?> declaredClass : TestActivityEnvironmentInternal.class.getDeclaredClasses()) {
+            if (declaredClass.getSimpleName().equals("WorkflowServiceWrapper")) {
+                return declaredClass;
+            }
+        }
+        throw new RuntimeException("Could not find WorkflowServiceWrapper inner class");
     }
 
-    // For non-primitive types, try to create an empty instance
-    if (type.getConstructors().length > 0
-        && Arrays.stream(type.getConstructors())
-            .anyMatch(constructor -> constructor.getParameterCount() == 0)) {
-      return type.getDeclaredConstructor().newInstance();
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        setupActivityExecutor();
+
+        setupWorkflowServiceWrapper();
     }
 
-    // Fallback for complex types
-    return null;
-  }
+    private void setupActivityExecutor() {
+        try {
+            // Find the inner class first
+            Class<?> innerClass = findTestActivityExecutorClass();
+
+            // Get the constructor with the specific parameter types
+            Constructor<?> constructor =
+                    innerClass.getDeclaredConstructor(
+                            TestActivityEnvironmentInternal.class,
+                            IWorkflowService.class,
+                            WorkflowInterceptorBase.class);
+            constructor.setAccessible(true);
+
+            // Create an instance of the outer class
+            TestActivityEnvironmentInternal outerInstance = mock(TestActivityEnvironmentInternal.class);
+
+            // Create the instance
+            testActivityExecutor = constructor.newInstance(outerInstance, mockWorkflowService, mockNext);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Failed to set up test: " + e.getMessage(), e);
+        }
+    }
+
+    private void setupWorkflowServiceWrapper() {
+        try {
+            // Find the inner class first
+            Class<?> innerClass = findWorkflowServiceWrapperClass();
+
+            // Get the constructor with the specific parameter types
+            Constructor<?> constructor =
+                    innerClass.getDeclaredConstructor(
+                            TestActivityEnvironmentInternal.class, IWorkflowService.class);
+            constructor.setAccessible(true);
+
+            // Create an instance of the outer class
+            TestActivityEnvironmentInternal outerInstance = mock(TestActivityEnvironmentInternal.class);
+
+            // Create the instance
+            testWorkflowServiceWrapper = constructor.newInstance(outerInstance, mockWorkflowService);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Failed to set up test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void testWorkflowServiceWrapperMethodDelegation() throws Exception {
+        // Prepare test cases
+        List<MethodTestCase> testCases = prepareMethodTestCases();
+
+        // Test each method
+        for (MethodTestCase testCase : testCases) {
+            try {
+                // Find the method on the wrapper
+                Method wrapperMethod =
+                        testWorkflowServiceWrapper
+                                .getClass()
+                                .getMethod(testCase.methodName, testCase.parameterTypes);
+
+                // Invoke the method on the wrapper
+                wrapperMethod.invoke(testWorkflowServiceWrapper, testCase.arguments);
+
+                // Generic verification using reflection
+                verifyMethodInvocation(mockWorkflowService, testCase);
+
+            } catch (Exception e) {
+                // Rethrow to fail the test if any unexpected exception occurs
+                throw new AssertionError("Failed to test method: " + testCase.methodName, e);
+            }
+        }
+    }
+
+    @Test
+    public void testAllMethodsThrowUnsupportedOperationException() throws Exception {
+        // Define test cases for different methods
+        MethodTestCase[] methodCases = {
+                // Signature: newRandom()
+                new MethodTestCase("newRandom", new Class<?>[0], new Object[0]),
+
+                // Signature: signalExternalWorkflow(String, WorkflowExecution, String, Object[])
+                new MethodTestCase(
+                        "signalExternalWorkflow",
+                        new Class<?>[]{String.class, WorkflowExecution.class, String.class, Object[].class},
+                        new Object[]{
+                                "testSignal", mock(WorkflowExecution.class), "signalName", new Object[]{}
+                        }),
+
+                // Signature: signalExternalWorkflow(WorkflowExecution, String, Object[])
+                new MethodTestCase(
+                        "signalExternalWorkflow",
+                        new Class<?>[]{WorkflowExecution.class, String.class, Object[].class},
+                        new Object[]{mock(WorkflowExecution.class), "signalName", new Object[]{}}),
+
+                // Signature: cancelWorkflow(WorkflowExecution)
+                new MethodTestCase(
+                        "cancelWorkflow",
+                        new Class<?>[]{WorkflowExecution.class},
+                        new Object[]{mock(WorkflowExecution.class)}),
+
+                // Signature: sleep(Duration)
+                new MethodTestCase(
+                        "sleep", new Class<?>[]{Duration.class}, new Object[]{Duration.ofSeconds(1)}),
+
+                // Signature: await(Duration, String, Supplier)
+                new MethodTestCase(
+                        "await",
+                        new Class<?>[]{Duration.class, String.class, Supplier.class},
+                        new Object[]{Duration.ofSeconds(1), "testReason", (Supplier<?>) () -> true}),
+
+                // Signature: await(String, Supplier)
+                new MethodTestCase(
+                        "await",
+                        new Class<?>[]{String.class, Supplier.class},
+                        new Object[]{"testReason", (Supplier<?>) () -> true}),
+
+                // Signature: newTimer(Duration)
+                new MethodTestCase(
+                        "newTimer", new Class<?>[]{Duration.class}, new Object[]{Duration.ofSeconds(1)}),
+
+                // Signature: sideEffect(Class, Type, Functions.Func)
+                new MethodTestCase(
+                        "sideEffect",
+                        new Class<?>[]{Class.class, Type.class, Functions.Func.class},
+                        new Object[]{String.class, String.class, (Functions.Func<String>) () -> "test"}),
+
+                // Signature: mutableSideEffect(String, Class, Type, BiPredicate, Functions.Func)
+                new MethodTestCase(
+                        "mutableSideEffect",
+                        new Class<?>[]{
+                                String.class, Class.class, Type.class, BiPredicate.class, Functions.Func.class
+                        },
+                        new Object[]{
+                                "testId",
+                                String.class,
+                                String.class,
+                                (BiPredicate<String, String>) (a, b) -> false,
+                                (Functions.Func<String>) () -> "test"
+                        }),
+
+                // Signature: getVersion(String, int, int)
+                new MethodTestCase(
+                        "getVersion",
+                        new Class<?>[]{String.class, int.class, int.class},
+                        new Object[]{"changeId", 0, 1}),
+
+                // Signature: continueAsNew(Optional, Optional, Object[])
+                new MethodTestCase(
+                        "continueAsNew",
+                        new Class<?>[]{Optional.class, Optional.class, Object[].class},
+                        new Object[]{Optional.empty(), Optional.empty(), new Object[]{}}),
+
+                // Signature: registerQuery(String, Type[], Func1)
+                new MethodTestCase(
+                        "registerQuery",
+                        new Class<?>[]{String.class, Type[].class, Functions.Func1.class},
+                        new Object[]{
+                                "queryType",
+                                new Type[]{String.class},
+                                (Functions.Func1<Object[], Object>) args -> "result"
+                        }),
+
+                // Signature: randomUUID()
+                new MethodTestCase("randomUUID", new Class<?>[0], new Object[0]),
+
+                // Signature: upsertSearchAttributes(Map)
+                new MethodTestCase(
+                        "upsertSearchAttributes",
+                        new Class<?>[]{Map.class},
+                        new Object[]{java.util.Collections.emptyMap()})
+        };
+
+        // Test each method
+        for (MethodTestCase testCase : methodCases) {
+            try {
+                // Find the method
+                Method method =
+                        testActivityExecutor
+                                .getClass()
+                                .getDeclaredMethod(testCase.methodName, testCase.parameterTypes);
+                method.setAccessible(true);
+
+                // Invoke the method
+                Object result = method.invoke(testActivityExecutor, testCase.arguments);
+
+                // If we get here, the method did not throw UnsupportedOperationException
+                fail("Expected UnsupportedOperationException for method " + testCase.methodName);
+
+            } catch (Exception e) {
+                // Check if the cause is UnsupportedOperationException
+                if (!(e.getCause() instanceof UnsupportedOperationException)) {
+                    // If it's not the expected exception, rethrow
+                    throw new RuntimeException("Unexpected exception for method " + testCase.methodName, e);
+                }
+                // Expected behavior - UnsupportedOperationException was thrown
+                // Continue to next method
+            }
+        }
+    }
+
+    // Helper class to encapsulate method test cases
+    private static class MethodTestCase {
+        String methodName;
+        Class<?>[] parameterTypes;
+        Object[] arguments;
+
+        MethodTestCase(String methodName, Class<?>[] parameterTypes, Object[] arguments) {
+            this.methodName = methodName;
+            this.parameterTypes = parameterTypes;
+            this.arguments = arguments;
+        }
+    }
+
+    /**
+     * Generic method to verify method invocation on mock
+     */
+    private void verifyMethodInvocation(Object mockObject, MethodTestCase testCase) throws Exception {
+        // Use Mockito's verify with reflection
+        if (testCase.arguments.length == 0) {
+            // For methods with no arguments
+            verify(mockObject).getClass().getMethod(testCase.methodName).invoke(mockObject);
+        } else {
+            // For methods with arguments
+            Method verifyMethod = org.mockito.Mockito.class.getMethod("verify", Object.class);
+            Object verifiedMock = verifyMethod.invoke(null, mockObject);
+
+            // Invoke the method on the verified mock
+            verifiedMock
+                    .getClass()
+                    .getMethod(testCase.methodName, testCase.parameterTypes)
+                    .invoke(verifiedMock, testCase.arguments);
+        }
+    }
+
+    /**
+     * Prepares test cases for all methods in IWorkflowService
+     */
+    private List<MethodTestCase> prepareMethodTestCases() throws Exception {
+        List<MethodTestCase> testCases = new ArrayList<>();
+
+        // You can add more methods here as needed
+        // Dynamically discover and add more methods from IWorkflowService if required
+        Method[] allMethods = IWorkflowService.class.getMethods();
+        for (Method method : allMethods) {
+            testCases.add(createDefaultMethodTestCase(method));
+        }
+        return testCases;
+    }
+
+    /**
+     * Creates a default MethodTestCase for a given method
+     */
+    private MethodTestCase createDefaultMethodTestCase(Method method) throws Exception {
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        Object[] arguments = new Object[parameterTypes.length];
+
+        for (int i = 0; i < parameterTypes.length; i++) {
+            arguments[i] = createDefaultArgument(parameterTypes[i]);
+        }
+
+        return new MethodTestCase(method.getName(), parameterTypes, arguments);
+    }
+
+    /**
+     * Creates a default argument for different parameter types
+     */
+    private Object createDefaultArgument(Class<?> type) throws Exception {
+        if (type.isPrimitive()) {
+            if (type == boolean.class) return false;
+            if (type == char.class) return '\u0000';
+            if (type == byte.class) return (byte) 0;
+            if (type == short.class) return (short) 0;
+            if (type == int.class) return 0;
+            if (type == long.class) return 0L;
+            if (type == float.class) return 0.0f;
+            if (type == double.class) return 0.0d;
+        }
+
+        // For non-primitive types, try to create an empty instance
+        if (type.getConstructors().length > 0
+                && Arrays.stream(type.getConstructors())
+                .anyMatch(constructor -> constructor.getParameterCount() == 0)) {
+            return type.getDeclaredConstructor().newInstance();
+        }
+
+        // Fallback for complex types
+        return null;
+    }
 }

--- a/src/test/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternalTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternalTest.java
@@ -86,7 +86,6 @@ public class TestActivityEnvironmentInternalTest {
               TestActivityEnvironmentInternal.class,
               IWorkflowService.class,
               WorkflowInterceptorBase.class);
-      constructor.setAccessible(true);
 
       // Create an instance of the outer class
       TestActivityEnvironmentInternal outerInstance = mock(TestActivityEnvironmentInternal.class);
@@ -108,7 +107,6 @@ public class TestActivityEnvironmentInternalTest {
       Constructor<?> constructor =
           innerClass.getDeclaredConstructor(
               TestActivityEnvironmentInternal.class, IWorkflowService.class);
-      constructor.setAccessible(true);
 
       // Create an instance of the outer class
       TestActivityEnvironmentInternal outerInstance = mock(TestActivityEnvironmentInternal.class);
@@ -125,8 +123,6 @@ public class TestActivityEnvironmentInternalTest {
   public void testWorkflowServiceWrapperMethodDelegation() throws Exception {
     // Prepare test cases
     List<MethodTestCase> testCases = prepareMethodTestCases();
-
-    System.out.println(testCases);
 
     // Test each method
     for (MethodTestCase testCase : testCases) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added unit tests for DecisionTaskWithHistoryIterator inside Replayer.
I had to go with instanstiating private class, otherwise I need to build the whole history for replayer.

<!-- Tell your future self why have you made these changes -->
**Why?**
Improving code coverage.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
