### PR TITLE
Set skipArchival to true for getResultAsync

### DIFF
--- a/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java
+++ b/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java
@@ -274,6 +274,7 @@ public class WorkflowExecutionUtils {
     request.setExecution(workflowExecution);
     request.setHistoryEventFilterType(HistoryEventFilterType.CLOSE_EVENT);
     request.setWaitForNewEvent(true);
+    request.setSkipArchival(true);
     request.setNextPageToken(pageToken);
     CompletableFuture<GetWorkflowExecutionHistoryResponse> response =
         getWorkflowExecutionHistoryAsync(service, request, timeout, unit);


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Set skipArchival to true for the async flows. This is done in the [sync flows](https://github.com/cadence-workflow/cadence-java-client/blob/master/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java#L195).

<!-- Tell your future self why have you made these changes -->
**Why?**
- When a request comes for workflow history, if the workflow doesn't exist and skipArchival is set to false then it immediately returns a BadRequestError. This results in there being no retries whatsoever (since BadRequestError isn't retried).
- When requests go to the passive region they won't immediately observe the workflow existing (due to replication delay), so these requests will always fail.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
