### PR TITLE
add github action for version releases to Sonatype

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           OSSATUBER_PASSWORD: ${{ secrets.OSSATUBER_PASSWORD }}
           OSSATUBER_USERNAME: ${{ secrets.OSSATUBER_USERNAME }}
         run: | # TODO old way of setting the properties from environment variables in gradle
-          ./gradlew publishToSonatype --info \
+          ./gradlew publishToSonatype closeSonatypeStagingRepository --info \
            -Psigning.keyId="${SIGNING_KEY_ID}" \
             -Psigning.password="${SIGNING_PASSWORD}" \
             -Psigning.key="${SIGNING_KEY}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release to Maven Central
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Version to release (if empty, derive from project version)'
+        required: false
+  # Automatic trigger on pushing a version tag (e.g., "v1.2.3")
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    container:
+      image: adoptopenjdk/openjdk11:jdk-11.0.10_9
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Install necessary tooling
+        env:
+          APACHE_THRIFT_VERSION: 0.9.3
+        run: |
+          apt-get update &&apt-get install -y wget gcc make build-essential git
+
+          wget https://archive.apache.org/dist/thrift/${APACHE_THRIFT_VERSION}/thrift-${APACHE_THRIFT_VERSION}.tar.gz && \
+          tar -xvf thrift-${APACHE_THRIFT_VERSION}.tar.gz && \
+          rm thrift-${APACHE_THRIFT_VERSION}.tar.gz && \
+          cd thrift-${APACHE_THRIFT_VERSION}/ && \
+          ./configure --enable-libs=no --enable-tests=no --enable-tutorial=no --with-cpp=no --with-c_glib=no --with-java=yes --with-ruby=no --with-erlang=no --with-go=no --with-nodejs=no --with-python=no && \
+          make && \
+          make install && \
+          cd .. && \
+          rm -rf thrift-${APACHE_THRIFT_VERSION}
+
+      - name: Determine release version
+        id: vars
+        run: |
+          # Derive the release version (drop "-SNAPSHOT") from Gradle project or input
+          VERSION_INPUT="${{ github.event.inputs.release_version || '' }}"
+          if [ -n "$VERSION_INPUT" ]; then
+            RELEASE_VERSION="$VERSION_INPUT"
+          else
+            # Read version from build.gradle
+            RELEASE_VERSION=$(grep -E 'version\s*=' build.gradle | sed "s/[[:space:]]*version[[:space:]]*=[[:space:]]*'\(.*\)'/\1/")
+          fi
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+
+      - name: Publish to Sonatype OSSRH (Maven Central)
+        env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          OSSATUBER_PASSWORD: ${{ secrets.OSSATUBER_PASSWORD }}
+          OSSATUBER_USERNAME: ${{ secrets.OSSATUBER_USERNAME }}
+        run: ./gradlew publishToSonatype closeSonatypeStagingRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,21 +40,21 @@ jobs:
       - name: Determine release version
         id: vars
         run: |
-          # Derive the release version (drop "-SNAPSHOT") from Gradle project or input
-          VERSION_INPUT="${{ github.event.inputs.release_version || '' }}"
-          if [ -n "$VERSION_INPUT" ]; then
-            RELEASE_VERSION="$VERSION_INPUT"
-          else
-            # Read version from build.gradle
-            RELEASE_VERSION=$(grep -E 'version\s*=' build.gradle | sed "s/[[:space:]]*version[[:space:]]*=[[:space:]]*'\(.*\)'/\1/")
-          fi
+          # Read version from build.gradle
+          RELEASE_VERSION=$(grep -E 'version\s*=' build.gradle | sed "s/[[:space:]]*version[[:space:]]*=[[:space:]]*'\(.*\)'/\1/")
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
 
       - name: Publish to Sonatype OSSRH (Maven Central)
         env:
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           OSSATUBER_PASSWORD: ${{ secrets.OSSATUBER_PASSWORD }}
           OSSATUBER_USERNAME: ${{ secrets.OSSATUBER_USERNAME }}
-        run: ./gradlew publishToSonatype closeSonatypeStagingRepository
+        run: | # TODO old way of setting the properties from environment variables in gradle
+          ./gradlew publishToSonatype --info \
+           -Psigning.keyId="${SIGNING_KEY_ID}" \
+            -Psigning.password="${SIGNING_PASSWORD}" \
+            -Psigning.key="${SIGNING_KEY}" \
+            -PossrhPassword="${OSSATUBER_PASSWORD}" \
+            -PossrhUsername="${OSSATUBER_USERNAME}"

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ src/main/idls/*
 .classpath
 .project
 .settings
+.vscode

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ googleJavaFormat {
 tasks.googleJavaFormat.dependsOn 'license'
 
 group = 'com.uber.cadence'
-version = '3.12.6'
+version = '3.12.7-SNAPSHOT'
 
 description = '''Uber Cadence Java Client'''
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,11 @@ plugins {
 }
 
 ext {
-    signingKey = System.getenv("SIGNING_KEY")
-    signingPassword = System.getenv("SIGNING_PASSWORD")
-    signingKeyId = System.getenv("SIGNING_KEY_ID")
-    ossrhUsername = hasProperty('ossrhUsername') ? property('ossrhUsername') : System.getenv("OSSATUBER_USERNAME")
-    ossrhPassword = hasProperty('ossrhPassword') ? property('ossrhPassword') : System.getenv("OSSATUBER_PASSWORD")
+    ossrhUsername = findProperty('ossrhUsername')
+    ossrhPassword = findProperty('ossrhPassword')
+    signingKeyId = findProperty('signing.keyId')
+    signingKey = findProperty('signing.key')
+    signingPassword = findProperty('signing.password')
 }
 
 repositories {
@@ -47,7 +47,7 @@ googleJavaFormat {
 tasks.googleJavaFormat.dependsOn 'license'
 
 group = 'com.uber.cadence'
-version = '3.12.7-SNAPSHOT'
+version = '3.12.6'
 
 description = '''Uber Cadence Java Client'''
 
@@ -142,6 +142,7 @@ protobuf {
         }
     }
     generateProtoTasks {
+        all().each { task -> task.dependsOn updateDlsSubmodule }
         all()*.plugins {
             grpc {
                 outputSubDir = 'java'
@@ -284,11 +285,23 @@ nexusPublishing {
     }
 }
 
-if (hasProperty('signing.keyId')) {
+if (signingKeyId) {
     apply plugin: 'signing'
-    signing {
-        sign configurations.archives
-        sign publishing.publications.mavenJava
+    if (signingKey) { // for CI
+        signing {
+            useInMemoryPgpKeys(
+                signingKeyId,
+                signingKey.replace('\\n','\n'),
+                signingPassword
+            )
+            sign configurations.archives
+            sign publishing.publications.mavenJava
+        }
+    } else {
+        signing {
+            sign configurations.archives
+            sign publishing.publications.mavenJava
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,15 @@ plugins {
     id 'java-library'
     id 'jacoco'
     id 'com.google.protobuf' version '0.8.11'
+    id("io.github.gradle-nexus.publish-plugin") version "1.3.0"  // Nexus publishing
+}
+
+ext {
+    signingKey = System.getenv("SIGNING_KEY")
+    signingPassword = System.getenv("SIGNING_PASSWORD")
+    signingKeyId = System.getenv("SIGNING_KEY_ID")
+    ossrhUsername = hasProperty('ossrhUsername') ? property('ossrhUsername') : System.getenv("OSSATUBER_USERNAME")
+    ossrhPassword = hasProperty('ossrhPassword') ? property('ossrhPassword') : System.getenv("OSSATUBER_PASSWORD")
 }
 
 repositories {
@@ -38,7 +47,7 @@ googleJavaFormat {
 tasks.googleJavaFormat.dependsOn 'license'
 
 group = 'com.uber.cadence'
-version = '3.12.6'
+version = '3.12.7-SNAPSHOT'
 
 description = '''Uber Cadence Java Client'''
 
@@ -133,7 +142,6 @@ protobuf {
         }
     }
     generateProtoTasks {
-        all().each { task -> task.dependsOn updateDlsSubmodule }
         all()*.plugins {
             grpc {
                 outputSubDir = 'java'
@@ -214,9 +222,6 @@ artifacts {
     archives javadocJar, sourcesJar
 }
 
-def ossrhUsername = hasProperty('ossrhUsername') ? property('ossrhUsername') : ''
-def ossrhPassword = hasProperty('ossrhPassword') ? property('ossrhPassword') : ''
-
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -264,6 +269,17 @@ publishing {
             } else {
                 url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
             }
+        }
+    }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            username.set(ossrhUsername)
+            password.set(ossrhPassword)
+            nexusUrl.set(uri("https://oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://oss.sonatype.org/content/repositories/snapshots/"))
         }
     }
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* added a github action release.yaml on push-tag and manual triggers (For safety, currently it's only auto-push-to-staging-and-close mode and requires manual release on sonatype) 
* added gralde nexus plugin
* bump version to 3.12.7-SNAPSHOT

Plan:
after it's tested against some version upgrade, we can switch mode to auto-release

<!-- Tell your future self why have you made these changes -->
**Why?**

Releasing requires PGP key access + sonatype access. These overheads slow down the release process

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Tested nexus plugin locally on staging repository
Test with act locally

```
act -j release --secret-file dummy
...
[Release to Maven Central/release]   ✅  Success - Main Publish to Sonatype OSSRH (Maven Central) [2m0.223553458s]
[Release to Maven Central/release] ⭐ Run Complete job
[Release to Maven Central/release] Cleaning up container for job release
[Release to Maven Central/release]   ✅  Success - Complete job
[Release to Maven Central/release] 🏁  Job succeeded
```
![Screenshot 2025-05-01 at 3 12 35 PM](https://github.com/user-attachments/assets/51e7a731-548f-48ed-9f76-5aa6e5910cdf)



<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
