### PR TITLE
support for "test runner for java" extension in vscode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,12 +170,26 @@ compileJava {
     options.encoding = 'UTF-8'
     options.compilerArgs << '-Xlint:none' << '-Xlint:deprecation' << '-Werror'
     options.errorprone.excludedPaths = '.*/generated-sources/.*'
+    options.errorprone {
+        disable('BadImport')
+        disable('PreferJavaTimeOverload')
+        disable('JavaTimeDefaultTimeZone')
+        disable('MutableConstantField')
+        disable('CatchFail')
+    }
 }
 
 compileTestJava {
     options.encoding = 'UTF-8'
     options.compilerArgs << '-Xlint:none' << '-Xlint:deprecation' << '-Werror'
     options.errorprone.excludedPaths = '.*/generated-sources/.*'
+    options.errorprone {
+        disable('BadImport')
+        disable('PreferJavaTimeOverload')
+        disable('JavaTimeDefaultTimeZone')
+        disable('MutableConstantField')
+        disable('CatchFail')
+    }
 }
 
 // Generation version.properties for value to be included into the request header


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* disable ErrorProne checks (some files are already violating but is suppressed due to Xlint:none)

<!-- Tell your future self why have you made these changes -->
**Why?**

Test Runner for Java extension for some reason doesn't read Xlint:none flag and thus fails on suppressed lint errors

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Locally tested on vscode

Before
![Screenshot 2025-05-20 at 12 47 32 PM](https://github.com/user-attachments/assets/63847c63-3350-447d-9705-0c4481c1ee74)

After
![Screenshot 2025-05-20 at 12 48 56 PM](https://github.com/user-attachments/assets/44541d24-5354-447d-b107-c9b226d505e7)


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
