### PR TITLE
Release use versions from git tags instead of static value

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,7 @@ jobs:
       - name: Determine release version
         id: vars
         run: |
-          # Read version from build.gradle
-          RELEASE_VERSION=$(grep -E 'version\s*=' build.gradle | sed "s/[[:space:]]*version[[:space:]]*=[[:space:]]*'\(.*\)'/\1/")
-          echo "RELEASE_VERSION=$RELEASE_VERSION"
-          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          ./gradlew -q printVersion
 
       - name: Publish to Sonatype OSSRH (Maven Central)
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,17 +15,20 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    container:
-      image: adoptopenjdk/openjdk11:jdk-11.0.10_9
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
-
+        uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'gradle'
       - name: Install necessary tooling
         env:
           APACHE_THRIFT_VERSION: 0.9.3
         run: |
-          apt-get update &&apt-get install -y wget gcc make build-essential git
+          apt-get update && apt-get install -y wget gcc make build-essential git
 
           wget https://archive.apache.org/dist/thrift/${APACHE_THRIFT_VERSION}/thrift-${APACHE_THRIFT_VERSION}.tar.gz && \
           tar -xvf thrift-${APACHE_THRIFT_VERSION}.tar.gz && \
@@ -42,6 +45,7 @@ jobs:
         run: |
           # Read version from build.gradle
           RELEASE_VERSION=$(grep -E 'version\s*=' build.gradle | sed "s/[[:space:]]*version[[:space:]]*=[[:space:]]*'\(.*\)'/\1/")
+          echo "RELEASE_VERSION=$RELEASE_VERSION"
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
 
       - name: Publish to Sonatype OSSRH (Maven Central)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
 - Fixed NullPointerException in ContextPropagation when Header is present but fields is null
 
 ## 3.11.0
-- Added opentracing support in workflow lifecycles #876 
+- Added opentracing support in workflow lifecycles #876
 
 ## 3.10.1
 - Fixed the bug: workflow already started for migration
@@ -121,12 +121,12 @@
 - Add CadenceChangeVersion support.
 - Allow using other tags in metric reporter.
 - Add metric tag to differentiate long-poll and normal request.
-### Changed 
+### Changed
 - Fix identity for sticky worker.
 - Improve contributing guide.
 
 ## 3.5.0
-### Changed 
+### Changed
 - Fix consistent query interface which caused overloading ambiguity with variable argument
 
 ## 3.4.0
@@ -318,5 +318,3 @@ to disable use FactoryOptions.disableStickyExecution property.
 - Side effects, mutable side effects, random uuid and workflow getVersion support.
 - Activity heartbeat throttling.
 - Deterministic retry of failed operation.
-
-

--- a/build.gradle
+++ b/build.gradle
@@ -51,13 +51,17 @@ group = 'com.uber.cadence'
 version = getVersion()
 
 def getVersion() {
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'describe', '--tags'
-        standardOutput = stdout
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'describe', '--tags'
+            standardOutput = stdout
+        }
+        def gitTag = stdout.toString().trim().replaceFirst("^v", "")
+        return gitTag
+    } catch (Exception e) {
+        return "0.0.0-LOCAL"
     }
-    def gitTag = stdout.toString().trim().replaceFirst("^v", "")
-    return gitTag
 }
 
 description = '''Uber Cadence Java Client'''

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,20 @@ googleJavaFormat {
 tasks.googleJavaFormat.dependsOn 'license'
 
 group = 'com.uber.cadence'
-version = '3.12.7-SNAPSHOT'
+
+version = getVersion()
+
+def getVersion() {
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    def gitTag = stdout.toString().trim().replaceFirst("^v", "")
+    return gitTag
+}
+
+println "current version: $version"
 
 description = '''Uber Cadence Java Client'''
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,6 @@ def getVersion() {
     return gitTag
 }
 
-println "current version: $version"
-
 description = '''Uber Cadence Java Client'''
 
 java {
@@ -107,6 +105,10 @@ license {
     header rootProject.file('license-header.txt')
     skipExistingHeaders true
     excludes(["**/*.json", "**/idls","com/uber/cadence/*.java", "com/uber/cadence/shadower/*.java"]) // config files and generated code
+}
+
+task printVersion {
+    println "current version: $version"
 }
 
 task initDlsSubmodule(type: Exec) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* gradle release now uses the version from git describe 
* added a handy task printVersion to get current version for release
* simplify the git action

<!-- Tell your future self why have you made these changes -->
**Why?**

Release rc versions requires code commits which slows down the release process.
Now tagging a value would just release rc version easily

**Future Plan**

If everything looks good, we can change the action to closeAndRelease directly.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Sample run
https://github.com/shijiesheng/cadence-java-client/actions/runs/15219317469/job/42811806456 

Repository is correctly closed.
<img width="857" alt="Screenshot 2025-05-23 at 3 01 54 PM" src="https://github.com/user-attachments/assets/904892b5-6263-4d5c-86d4-b4ca20eb15b3" />


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
