### PR TITLE
Remove raw history support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,17 +15,20 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    container:
-      image: adoptopenjdk/openjdk11:jdk-11.0.10_9
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
-
+        uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'gradle'
       - name: Install necessary tooling
         env:
           APACHE_THRIFT_VERSION: 0.9.3
         run: |
-          apt-get update &&apt-get install -y wget gcc make build-essential git
+          apt-get update && apt-get install -y wget gcc make build-essential git
 
           wget https://archive.apache.org/dist/thrift/${APACHE_THRIFT_VERSION}/thrift-${APACHE_THRIFT_VERSION}.tar.gz && \
           tar -xvf thrift-${APACHE_THRIFT_VERSION}.tar.gz && \
@@ -40,9 +43,7 @@ jobs:
       - name: Determine release version
         id: vars
         run: |
-          # Read version from build.gradle
-          RELEASE_VERSION=$(grep -E 'version\s*=' build.gradle | sed "s/[[:space:]]*version[[:space:]]*=[[:space:]]*'\(.*\)'/\1/")
-          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          ./gradlew -q printVersion
 
       - name: Publish to Sonatype OSSRH (Maven Central)
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.12.7
+- Release use versions from git tags instead of static value (#1002)
+- support for testrunner for java in vscode (#1001)
+- Fix(RequestMapper): Correctly map all fields (#1000)
+- add github action for version releases to Sonatype (#996)
+
 ## 3.12.6
 - Adding logs to internal shadower to check for failures log (#918)
 - Removing fossa as it is migrated to snyk (#919)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
 - Fixed NullPointerException in ContextPropagation when Header is present but fields is null
 
 ## 3.11.0
-- Added opentracing support in workflow lifecycles #876 
+- Added opentracing support in workflow lifecycles #876
 
 ## 3.10.1
 - Fixed the bug: workflow already started for migration
@@ -121,12 +121,12 @@
 - Add CadenceChangeVersion support.
 - Allow using other tags in metric reporter.
 - Add metric tag to differentiate long-poll and normal request.
-### Changed 
+### Changed
 - Fix identity for sticky worker.
 - Improve contributing guide.
 
 ## 3.5.0
-### Changed 
+### Changed
 - Fix consistent query interface which caused overloading ambiguity with variable argument
 
 ## 3.4.0
@@ -318,5 +318,3 @@ to disable use FactoryOptions.disableStickyExecution property.
 - Side effects, mutable side effects, random uuid and workflow getVersion support.
 - Activity heartbeat throttling.
 - Deterministic retry of failed operation.
-
-

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,22 @@ googleJavaFormat {
 tasks.googleJavaFormat.dependsOn 'license'
 
 group = 'com.uber.cadence'
-version = '3.12.7-SNAPSHOT'
+
+version = getVersion()
+
+def getVersion() {
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'describe', '--tags'
+            standardOutput = stdout
+        }
+        def gitTag = stdout.toString().trim().replaceFirst("^v", "")
+        return gitTag
+    } catch (Exception e) {
+        return "0.0.0-LOCAL"
+    }
+}
 
 description = '''Uber Cadence Java Client'''
 
@@ -94,6 +109,10 @@ license {
     header rootProject.file('license-header.txt')
     skipExistingHeaders true
     excludes(["**/*.json", "**/idls","com/uber/cadence/*.java", "com/uber/cadence/shadower/*.java"]) // config files and generated code
+}
+
+task printVersion {
+    println "current version: $version"
 }
 
 task initDlsSubmodule(type: Exec) {

--- a/build.gradle
+++ b/build.gradle
@@ -170,12 +170,26 @@ compileJava {
     options.encoding = 'UTF-8'
     options.compilerArgs << '-Xlint:none' << '-Xlint:deprecation' << '-Werror'
     options.errorprone.excludedPaths = '.*/generated-sources/.*'
+    options.errorprone {
+        disable('BadImport')
+        disable('PreferJavaTimeOverload')
+        disable('JavaTimeDefaultTimeZone')
+        disable('MutableConstantField')
+        disable('CatchFail')
+    }
 }
 
 compileTestJava {
     options.encoding = 'UTF-8'
     options.compilerArgs << '-Xlint:none' << '-Xlint:deprecation' << '-Werror'
     options.errorprone.excludedPaths = '.*/generated-sources/.*'
+    options.errorprone {
+        disable('BadImport')
+        disable('PreferJavaTimeOverload')
+        disable('JavaTimeDefaultTimeZone')
+        disable('MutableConstantField')
+        disable('CatchFail')
+    }
 }
 
 // Generation version.properties for value to be included into the request header

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/RequestMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/RequestMapper.java
@@ -169,6 +169,12 @@ public class RequestMapper {
             .setDomain(t.getDomain())
             .setWorkflowExecution(workflowExecution(t.getWorkflowExecution()))
             .setRequestId(t.getRequestId());
+    if (t.getCause() != null) {
+      builder.setCause(t.getCause());
+    }
+    if (t.getFirstExecutionRunID() != null) {
+      builder.setFirstExecutionRunId(t.getFirstExecutionRunID());
+    }
     if (t.getIdentity() != null) {
       builder.setIdentity(t.getIdentity());
     }
@@ -437,7 +443,8 @@ public class RequestMapper {
             .setRequestId(t.getRequestId())
             .setMemo(memo(t.getMemo()))
             .setSearchAttributes(searchAttributes(t.getSearchAttributes()))
-            .setHeader(header(t.getHeader()));
+            .setHeader(header(t.getHeader()))
+            .setJitterStart(secondsToDuration(t.getJitterStartSeconds()));
     if (t.getRetryPolicy() != null) {
       builder.setRetryPolicy(retryPolicy(t.getRetryPolicy()));
     }
@@ -521,7 +528,8 @@ public class RequestMapper {
             .setMemo(memo(t.getMemo()))
             .setSearchAttributes(searchAttributes(t.getSearchAttributes()))
             .setHeader(header(t.getHeader()))
-            .setDelayStart(secondsToDuration(t.getDelayStartSeconds()));
+            .setDelayStart(secondsToDuration(t.getDelayStartSeconds()))
+            .setJitterStart(secondsToDuration(t.getJitterStartSeconds()));
     if (t.getRetryPolicy() != null) {
       request.setRetryPolicy(retryPolicy(t.getRetryPolicy()));
     }
@@ -560,6 +568,9 @@ public class RequestMapper {
             .setDetails(payload(t.getDetails()));
     if (t.getIdentity() != null) {
       builder.setIdentity(t.getIdentity());
+    }
+    if (t.getFirstExecutionRunID() != null) {
+      builder.setFirstExecutionRunId(t.getFirstExecutionRunID());
     }
     return builder.build();
   }

--- a/src/main/java/com/uber/cadence/internal/shadowing/ReplayWorkflowActivityImpl.java
+++ b/src/main/java/com/uber/cadence/internal/shadowing/ReplayWorkflowActivityImpl.java
@@ -19,12 +19,9 @@ import static com.uber.cadence.internal.errors.ErrorType.UNKNOWN_WORKFLOW_TYPE;
 
 import com.google.common.collect.Lists;
 import com.uber.cadence.GetWorkflowExecutionHistoryResponse;
-import com.uber.cadence.History;
 import com.uber.cadence.HistoryEvent;
-import com.uber.cadence.HistoryEventFilterType;
 import com.uber.cadence.activity.Activity;
 import com.uber.cadence.common.WorkflowExecutionHistory;
-import com.uber.cadence.internal.common.InternalUtils;
 import com.uber.cadence.internal.common.RpcRetryer;
 import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.metrics.MetricsType;
@@ -185,14 +182,10 @@ public final class ReplayWorkflowActivityImpl implements ReplayWorkflowActivity 
                       nextPageToken, this.serviceClient, domain, execution.toThrift()));
       pageToken = resp.getNextPageToken();
 
-      // handle raw history
+      // TODO support raw history feature once server removes default Thrift encoding
       if (resp.getRawHistory() != null && resp.getRawHistory().size() > 0) {
-        History history =
-            InternalUtils.DeserializeFromBlobDataToHistory(
-                resp.getRawHistory(), HistoryEventFilterType.ALL_EVENT);
-        if (history != null && history.getEvents() != null) {
-          histories.addAll(history.getEvents());
-        }
+        throw new UnsupportedOperationException(
+            "Raw history is not supported. Please turn off frontend.sendRawWorkflowHistory feature flag in frontend service to recover");
       } else {
         histories.addAll(resp.getHistory().getEvents());
       }

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
@@ -18,7 +18,6 @@
 package com.uber.cadence.internal.testservice;
 
 import com.uber.cadence.BadRequestError;
-import com.uber.cadence.DataBlob;
 import com.uber.cadence.EntityNotExistsError;
 import com.uber.cadence.EventType;
 import com.uber.cadence.GetWorkflowExecutionHistoryRequest;
@@ -34,7 +33,6 @@ import com.uber.cadence.PollForDecisionTaskResponse;
 import com.uber.cadence.StickyExecutionAttributes;
 import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.WorkflowExecutionInfo;
-import com.uber.cadence.internal.common.InternalUtils;
 import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.testservice.RequestContext.Timer;
 import java.time.Duration;
@@ -348,12 +346,10 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
       if (!getRequest.isWaitForNewEvent()
           && getRequest.getHistoryEventFilterType() != HistoryEventFilterType.CLOSE_EVENT) {
         List<HistoryEvent> events = history.getEventsLocked();
-        List<DataBlob> blobs = InternalUtils.SerializeFromHistoryEventToBlobData(events);
         // Copy the list as it is mutable. Individual events assumed immutable.
         ArrayList<HistoryEvent> eventsCopy = new ArrayList<>(events);
         return new GetWorkflowExecutionHistoryResponse()
-            .setHistory(new History().setEvents(eventsCopy))
-            .setRawHistory(blobs);
+            .setHistory(new History().setEvents(eventsCopy));
       }
       expectedNextEventId = history.getNextEventIdLocked();
     } finally {
@@ -361,11 +357,9 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
     }
     List<HistoryEvent> events =
         history.waitForNewEvents(expectedNextEventId, getRequest.getHistoryEventFilterType());
-    List<DataBlob> blobs = InternalUtils.SerializeFromHistoryEventToBlobData(events);
     GetWorkflowExecutionHistoryResponse result = new GetWorkflowExecutionHistoryResponse();
     if (events != null) {
       result.setHistory(new History().setEvents(events));
-      result.setRawHistory(blobs);
     }
     return result;
   }

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -28,7 +28,6 @@ import com.uber.cadence.*;
 import com.uber.cadence.WorkflowService.GetWorkflowExecutionHistory_result;
 import com.uber.cadence.internal.Version;
 import com.uber.cadence.internal.common.CheckedExceptionWrapper;
-import com.uber.cadence.internal.common.InternalUtils;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.internal.metrics.ServiceMethod;
@@ -766,10 +765,8 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       if (response.getResponseCode() == ResponseCode.OK) {
         GetWorkflowExecutionHistoryResponse res = result.getSuccess();
         if (res.getRawHistory() != null) {
-          History history =
-              InternalUtils.DeserializeFromBlobDataToHistory(
-                  res.getRawHistory(), getRequest.getHistoryEventFilterType());
-          res.setHistory(history);
+          throw new TException(
+              "Raw history is not supported. Please turn off frontend.sendRawWorkflowHistory feature flag in frontend service to recover");
         }
         return res;
       }
@@ -2593,10 +2590,8 @@ public class WorkflowServiceTChannel implements IWorkflowService {
                 if (r.getResponseCode() == ResponseCode.OK) {
                   GetWorkflowExecutionHistoryResponse res = result.getSuccess();
                   if (res.getRawHistory() != null) {
-                    History history =
-                        InternalUtils.DeserializeFromBlobDataToHistory(
-                            res.getRawHistory(), getRequest.getHistoryEventFilterType());
-                    res.setHistory(history);
+                    throw new TException(
+                        "Raw history is not supported. Please turn off frontend.sendRawWorkflowHistory feature flag in frontend service to recover");
                   }
                   resultHandler.onComplete(res);
                   return;

--- a/src/test/java/com/uber/cadence/internal/common/InternalUtilsTest.java
+++ b/src/test/java/com/uber/cadence/internal/common/InternalUtilsTest.java
@@ -17,23 +17,14 @@
 
 package com.uber.cadence.internal.common;
 
-import static com.uber.cadence.EventType.WorkflowExecutionStarted;
 import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
-import com.google.common.collect.Lists;
-import com.googlecode.junittoolbox.MultithreadingTester;
-import com.googlecode.junittoolbox.RunnableAssert;
 import com.uber.cadence.*;
 import com.uber.cadence.converter.DataConverterException;
 import com.uber.cadence.workflow.WorkflowUtils;
 import java.io.FileOutputStream;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import junit.framework.TestCase;
 import org.junit.Test;
 
 public class InternalUtilsTest {
@@ -55,102 +46,5 @@ public class InternalUtilsTest {
     Map<String, Object> attr = new HashMap<>();
     attr.put("InvalidValue", new FileOutputStream("dummy"));
     InternalUtils.convertMapToSearchAttributes(attr);
-  }
-
-  @Test
-  public void testSerialization_History() {
-
-    RunnableAssert r =
-        new RunnableAssert("history_serialization") {
-          @Override
-          public void run() {
-            HistoryEvent event =
-                new HistoryEvent()
-                    .setEventId(1)
-                    .setVersion(1)
-                    .setEventType(WorkflowExecutionStarted)
-                    .setTimestamp(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC))
-                    .setWorkflowExecutionStartedEventAttributes(
-                        new WorkflowExecutionStartedEventAttributes()
-                            .setAttempt(1)
-                            .setFirstExecutionRunId("test"));
-
-            List<HistoryEvent> historyEvents = Lists.newArrayList(event);
-            History history = new History().setEvents(historyEvents);
-            DataBlob blob = InternalUtils.SerializeFromHistoryToBlobData(history);
-            assertNotNull(blob);
-
-            try {
-              History result =
-                  InternalUtils.DeserializeFromBlobDataToHistory(
-                      Lists.newArrayList(blob), HistoryEventFilterType.ALL_EVENT);
-              assertNotNull(result);
-              assertEquals(1, result.events.size());
-              assertEquals(event.getEventId(), result.events.get(0).getEventId());
-              assertEquals(event.getVersion(), result.events.get(0).getVersion());
-              assertEquals(event.getEventType(), result.events.get(0).getEventType());
-              assertEquals(event.getTimestamp(), result.events.get(0).getTimestamp());
-              assertEquals(
-                  event.getWorkflowExecutionStartedEventAttributes(),
-                  result.events.get(0).getWorkflowExecutionStartedEventAttributes());
-            } catch (Exception e) {
-              TestCase.fail("Received unexpected error during deserialization");
-            }
-          }
-        };
-
-    try {
-      new MultithreadingTester().add(r).numThreads(50).numRoundsPerThread(10).run();
-    } catch (Exception e) {
-      TestCase.fail("Received unexpected error during concurrent deserialization");
-    }
-  }
-
-  @Test
-  public void testSerialization_HistoryEvent() {
-
-    RunnableAssert r =
-        new RunnableAssert("history_event_serialization") {
-          @Override
-          public void run() {
-            HistoryEvent event =
-                new HistoryEvent()
-                    .setEventId(1)
-                    .setVersion(1)
-                    .setEventType(WorkflowExecutionStarted)
-                    .setTimestamp(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC))
-                    .setWorkflowExecutionStartedEventAttributes(
-                        new WorkflowExecutionStartedEventAttributes()
-                            .setAttempt(1)
-                            .setFirstExecutionRunId("test"));
-
-            List<HistoryEvent> historyEvents = Lists.newArrayList(event);
-            List<DataBlob> blobList =
-                InternalUtils.SerializeFromHistoryEventToBlobData(historyEvents);
-            assertEquals(1, blobList.size());
-
-            try {
-              List<HistoryEvent> result =
-                  InternalUtils.DeserializeFromBlobDataToHistoryEvents(blobList);
-              assertNotNull(result);
-              assertEquals(1, result.size());
-              assertEquals(event.getEventId(), result.get(0).getEventId());
-              assertEquals(event.getVersion(), result.get(0).getVersion());
-              assertEquals(event.getEventType(), result.get(0).getEventType());
-              assertEquals(event.getTimestamp(), result.get(0).getTimestamp());
-              assertEquals(
-                  event.getWorkflowExecutionStartedEventAttributes(),
-                  result.get(0).getWorkflowExecutionStartedEventAttributes());
-            } catch (Exception e) {
-              TestCase.fail("Received unexpected error during deserialization");
-            }
-          }
-        };
-
-    try {
-      new MultithreadingTester().add(r).numThreads(50).numRoundsPerThread(10).run();
-    } catch (Exception e) {
-      TestCase.fail("Received unexpected error during concurrent deserialization");
-    }
   }
 }

--- a/src/test/java/com/uber/cadence/internal/compatibility/ProtoObjects.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/ProtoObjects.java
@@ -874,6 +874,16 @@ public final class ProtoObjects {
               .setRequestId("requestId")
               .setIdentity("identity")
               .build();
+  public static final RequestCancelWorkflowExecutionRequest
+      REQUEST_CANCEL_WORKFLOW_EXECUTION_REQUEST_FULL =
+          RequestCancelWorkflowExecutionRequest.newBuilder()
+              .setDomain("domain")
+              .setWorkflowExecution(WORKFLOW_EXECUTION)
+              .setRequestId("requestId")
+              .setIdentity("identity")
+              .setFirstExecutionRunId("firstExecutionRunID")
+              .setCause("cancel cause")
+              .build();
   public static final ResetStickyTaskListRequest RESET_STICKY_TASK_LIST_REQUEST =
       ResetStickyTaskListRequest.newBuilder()
           .setDomain("domain")
@@ -1005,6 +1015,7 @@ public final class ProtoObjects {
           .setSearchAttributes(SEARCH_ATTRIBUTES)
           .setHeader(HEADER)
           .setDelayStart(seconds(3))
+          .setJitterStart(seconds(0))
           .build();
 
   public static final SignalWithStartWorkflowExecutionRequest SIGNAL_WITH_START_WORKFLOW_EXECUTION =
@@ -1042,6 +1053,16 @@ public final class ProtoObjects {
           .setReason("reason")
           .setDetails(payload("details"))
           .setIdentity("identity")
+          .build();
+
+  public static final TerminateWorkflowExecutionRequest TERMINATE_WORKFLOW_EXECUTION_REQUEST_FULL =
+      TerminateWorkflowExecutionRequest.newBuilder()
+          .setDomain("domain")
+          .setWorkflowExecution(WORKFLOW_EXECUTION)
+          .setReason("reason")
+          .setDetails(payload("details"))
+          .setIdentity("identity")
+          .setFirstExecutionRunId("firstExecutionRunID")
           .build();
 
   public static final DeprecateDomainRequest DEPRECATE_DOMAIN_REQUEST =

--- a/src/test/java/com/uber/cadence/internal/compatibility/ThriftObjects.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/ThriftObjects.java
@@ -746,6 +746,15 @@ public final class ThriftObjects {
               .setWorkflowExecution(WORKFLOW_EXECUTION)
               .setRequestId("requestId")
               .setIdentity("identity");
+  public static final RequestCancelWorkflowExecutionRequest
+      REQUEST_CANCEL_WORKFLOW_EXECUTION_REQUEST_FULL =
+          new RequestCancelWorkflowExecutionRequest()
+              .setDomain("domain")
+              .setWorkflowExecution(WORKFLOW_EXECUTION)
+              .setRequestId("requestId")
+              .setIdentity("identity")
+              .setFirstExecutionRunID("firstExecutionRunID")
+              .setCause("cancel cause");
   public static final ResetStickyTaskListRequest RESET_STICKY_TASK_LIST_REQUEST =
       new ResetStickyTaskListRequest().setDomain("domain").setExecution(WORKFLOW_EXECUTION);
   public static final ResetWorkflowExecutionRequest RESET_WORKFLOW_EXECUTION_REQUEST =
@@ -863,6 +872,7 @@ public final class ThriftObjects {
           .setMemo(MEMO)
           .setSearchAttributes(SEARCH_ATTRIBUTES)
           .setHeader(HEADER)
+          .setJitterStartSeconds(0)
           .setDelayStartSeconds(3);
   public static final com.uber.cadence.SignalWithStartWorkflowExecutionRequest
       SIGNAL_WITH_START_WORKFLOW_EXECUTION =
@@ -885,7 +895,8 @@ public final class ThriftObjects {
               .setMemo(MEMO)
               .setSearchAttributes(SEARCH_ATTRIBUTES)
               .setHeader(HEADER)
-              .setDelayStartSeconds(3);
+              .setDelayStartSeconds(3)
+              .setJitterStartSeconds(0);
 
   public static final StartWorkflowExecutionAsyncRequest START_WORKFLOW_EXECUTION_ASYNC_REQUEST =
       new StartWorkflowExecutionAsyncRequest().setRequest(START_WORKFLOW_EXECUTION);
@@ -912,6 +923,15 @@ public final class ThriftObjects {
           .setReason("reason")
           .setDetails(utf8("details"))
           .setIdentity("identity");
+
+  public static final TerminateWorkflowExecutionRequest TERMINATE_WORKFLOW_EXECUTION_REQUEST_FULL =
+      new TerminateWorkflowExecutionRequest()
+          .setDomain("domain")
+          .setWorkflowExecution(WORKFLOW_EXECUTION)
+          .setReason("reason")
+          .setDetails(utf8("details"))
+          .setIdentity("identity")
+          .setFirstExecutionRunID("firstExecutionRunID");
 
   public static final DeprecateDomainRequest DEPRECATE_DOMAIN_REQUEST =
       new DeprecateDomainRequest().setName("domain").setSecurityToken("securityToken");

--- a/src/test/java/com/uber/cadence/internal/compatibility/proto/RequestMapperTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/proto/RequestMapperTest.java
@@ -96,8 +96,12 @@ public class RequestMapperTest<
             ThriftObjects.REQUEST_CANCEL_WORKFLOW_EXECUTION_REQUEST,
             ProtoObjects.REQUEST_CANCEL_WORKFLOW_EXECUTION_REQUEST,
             RequestMapper::requestCancelWorkflowExecutionRequest,
-            "firstExecutionRunID",
-            "cause"),
+            "firstExecutionRunID", // optional field
+            "cause"), // optional field
+        testCase(
+            ThriftObjects.REQUEST_CANCEL_WORKFLOW_EXECUTION_REQUEST_FULL,
+            ProtoObjects.REQUEST_CANCEL_WORKFLOW_EXECUTION_REQUEST_FULL,
+            RequestMapper::requestCancelWorkflowExecutionRequest),
         testCase(
             ThriftObjects.RESET_STICKY_TASK_LIST_REQUEST,
             ProtoObjects.RESET_STICKY_TASK_LIST_REQUEST,
@@ -157,13 +161,11 @@ public class RequestMapperTest<
         testCase(
             ThriftObjects.START_WORKFLOW_EXECUTION,
             ProtoObjects.START_WORKFLOW_EXECUTION,
-            RequestMapper::startWorkflowExecutionRequest,
-            "jitterStartSeconds"),
+            RequestMapper::startWorkflowExecutionRequest),
         testCase(
             ThriftObjects.SIGNAL_WITH_START_WORKFLOW_EXECUTION,
             ProtoObjects.SIGNAL_WITH_START_WORKFLOW_EXECUTION,
-            RequestMapper::signalWithStartWorkflowExecutionRequest,
-            "jitterStartSeconds"),
+            RequestMapper::signalWithStartWorkflowExecutionRequest),
         testCase(
             ThriftObjects.START_WORKFLOW_EXECUTION_ASYNC_REQUEST,
             ProtoObjects.START_WORKFLOW_EXECUTION_ASYNC_REQUEST,
@@ -180,7 +182,11 @@ public class RequestMapperTest<
             ThriftObjects.TERMINATE_WORKFLOW_EXECUTION_REQUEST,
             ProtoObjects.TERMINATE_WORKFLOW_EXECUTION_REQUEST,
             RequestMapper::terminateWorkflowExecutionRequest,
-            "firstExecutionRunID"),
+            "firstExecutionRunID"), // optional field
+        testCase(
+            ThriftObjects.TERMINATE_WORKFLOW_EXECUTION_REQUEST_FULL,
+            ProtoObjects.TERMINATE_WORKFLOW_EXECUTION_REQUEST_FULL,
+            RequestMapper::terminateWorkflowExecutionRequest),
         testCase(
             ThriftObjects.DEPRECATE_DOMAIN_REQUEST,
             ProtoObjects.DEPRECATE_DOMAIN_REQUEST,
@@ -189,12 +195,12 @@ public class RequestMapperTest<
             ThriftObjects.DESCRIBE_DOMAIN_BY_ID_REQUEST,
             ProtoObjects.DESCRIBE_DOMAIN_BY_ID_REQUEST,
             RequestMapper::describeDomainRequest,
-            "name"),
+            "name"), // Not needed for query by ID
         testCase(
             ThriftObjects.DESCRIBE_DOMAIN_BY_NAME_REQUEST,
             ProtoObjects.DESCRIBE_DOMAIN_BY_NAME_REQUEST,
             RequestMapper::describeDomainRequest,
-            "uuid"),
+            "uuid"), // Not needed for query by name
         testCase(
             ThriftObjects.LIST_DOMAINS_REQUEST,
             ProtoObjects.LIST_DOMAINS_REQUEST,
@@ -227,7 +233,7 @@ public class RequestMapperTest<
             ThriftObjects.REGISTER_DOMAIN_REQUEST,
             ProtoObjects.REGISTER_DOMAIN_REQUEST,
             RequestMapper::registerDomainRequest,
-            "emitMetric"),
+            "emitMetric"), // Thrift has this field but proto doens't have it
         testCase(
             ThriftObjects.UPDATE_DOMAIN_REQUEST,
             // Data and replicationConfiguration are copied incorrectly due to a bug :(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Remove raw history support in client

<!-- Tell your future self why have you made these changes -->
**Why?**

History is stored as Thrift encoded binary. Sending raw history in Thrift will no longer be supported in V4

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit Test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
