### PR TITLE
Add attempt number to structured activity logger

### DIFF
--- a/src/main/java/com/uber/cadence/internal/logging/LoggerTag.java
+++ b/src/main/java/com/uber/cadence/internal/logging/LoggerTag.java
@@ -25,4 +25,5 @@ public class LoggerTag {
   public static final String TASK_LIST = "TaskList";
   public static final String WORKFLOW_ID = "WorkflowID";
   public static final String WORKFLOW_TYPE = "WorkflowType";
+  public static final String ATTEMPT = "Attempt";
 }

--- a/src/main/java/com/uber/cadence/internal/worker/ActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/ActivityWorker.java
@@ -144,6 +144,7 @@ public class ActivityWorker extends SuspendableWorkerBase {
       MDC.put(LoggerTag.ACTIVITY_TYPE, task.getActivityType().getName());
       MDC.put(LoggerTag.WORKFLOW_ID, task.getWorkflowExecution().getWorkflowId());
       MDC.put(LoggerTag.RUN_ID, task.getWorkflowExecution().getRunId());
+      MDC.put(LoggerTag.ATTEMPT, String.valueOf(task.getAttempt()));
 
       propagateContext(task);
       Span span = spanFactory.spanForExecuteActivity(task);
@@ -175,6 +176,7 @@ public class ActivityWorker extends SuspendableWorkerBase {
         MDC.remove(LoggerTag.ACTIVITY_TYPE);
         MDC.remove(LoggerTag.WORKFLOW_ID);
         MDC.remove(LoggerTag.RUN_ID);
+        MDC.remove(LoggerTag.ATTEMPT);
         unsetCurrentContext();
       }
     }


### PR DESCRIPTION
**What changed?**
Added attempt number logging to activity execution. This includes:
- Added a new ATTEMPT constant to LoggerTag.java
- Enhanced ActivityWorker.java to include the attempt number in the MDC during activity execution.

<!-- Tell your future self why have you made these changes -->
**Why?**
To improve observability and debugging capabilities for activity executions by including the Attempt number


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally against the java-samples and verified that attempt numbers showed up.
<img width="1016" height="315" alt="image" src="https://github.com/user-attachments/assets/0be43bc3-ace9-4003-92b6-27ab11d98d0c" />
Will also rely on GitHub Actions builds


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**
Very low risk change, only adds additional logging context, doesn't modify core business logic

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Minor enhancement: Activity execution logs now include attempt number for better retry debugging and observability.

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
No configuration or setup documentation changes required. This is an internal logging enhancement that improves observability without requiring user configuration changes.