### PR TITLE
fix: Data race on failedPromises in DeterministicRunnerImpl

### DIFF
--- a/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
@@ -53,6 +53,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -121,7 +122,7 @@ class DeterministicRunnerImpl implements DeterministicRunner {
    * Used to check for failedPromises that contain an error, but never where accessed. It is to
    * avoid failure swallowing by failedPromises which is very hard to troubleshoot.
    */
-  private Set<Promise> failedPromises = new HashSet<>();
+  private Set<Promise> failedPromises = ConcurrentHashMap.newKeySet();
 
   private boolean exitRequested;
   private Object exitValue;


### PR DESCRIPTION
**What changed?**
 Replace `HashSet` with `ConcurrentHashMap.newKeySet()` for `failedPromises` in `DeterministicRunnerImpl`.

**Why?**
`failedPromises` is written to via `registerFailedPromise`/`forgetFailedPromise` without holding the lock, while `close()` reads it under the lock on another thread. 

**How did you test it?**
Existing unit tests.

**Potential risks**
Minimal. `ConcurrentHashMap.newKeySet()` is a drop-in replacement for `HashSet` but has slightly higher memory overhead and per-operation.

**Release notes**
N/A

**Documentation Changes**
N/A