### PR TITLE
feat(schedule): support creating schedule in paused state

### DIFF
--- a/src/main/java/com/uber/cadence/client/ScheduleClient.java
+++ b/src/main/java/com/uber/cadence/client/ScheduleClient.java
@@ -29,6 +29,7 @@ import com.uber.cadence.UpdateScheduleResponse;
 import com.uber.cadence.client.schedule.ScheduleAction;
 import com.uber.cadence.client.schedule.ScheduleCatchUpPolicy;
 import com.uber.cadence.client.schedule.ScheduleDescription;
+import com.uber.cadence.client.schedule.ScheduleInitialState;
 import com.uber.cadence.client.schedule.SchedulePolicies;
 import com.uber.cadence.client.schedule.ScheduleSpec;
 import java.util.List;
@@ -73,6 +74,25 @@ public interface ScheduleClient {
    */
   CompletableFuture<CreateScheduleResponse> createSchedule(
       String scheduleId, ScheduleSpec spec, ScheduleAction action, SchedulePolicies policies);
+
+  /**
+   * Creates a new schedule in a specific initial state using clean client types. Pass a {@link
+   * ScheduleInitialState} with {@code paused = true} to start the schedule already paused, avoiding
+   * a subsequent {@link #pauseSchedule} call.
+   *
+   * @param scheduleId unique identifier for the schedule within the domain
+   * @param spec when and how often the schedule fires
+   * @param action what to do on each firing (start a workflow)
+   * @param policies overlap, catch-up, and failure-handling policies
+   * @param initialState optional initial pause state; {@code null} behaves like the four-arg
+   *     overload
+   */
+  CompletableFuture<CreateScheduleResponse> createSchedule(
+      String scheduleId,
+      ScheduleSpec spec,
+      ScheduleAction action,
+      SchedulePolicies policies,
+      ScheduleInitialState initialState);
 
   /**
    * Returns the current configuration and runtime state of a schedule.

--- a/src/main/java/com/uber/cadence/client/schedule/ScheduleInitialState.java
+++ b/src/main/java/com/uber/cadence/client/schedule/ScheduleInitialState.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * <p>Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+ * except in compliance with the License. A copy of the License is located at
+ *
+ * <p>http://aws.amazon.com/apache2.0
+ *
+ * <p>or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.uber.cadence.client.schedule;
+
+import java.util.Objects;
+
+/**
+ * Initial pause state supplied on {@link
+ * com.uber.cadence.client.ScheduleClient#createSchedule(String, ScheduleSpec, ScheduleAction,
+ * SchedulePolicies, ScheduleInitialState)} to create a schedule already paused. {@code pausedAt} is
+ * server-populated and therefore not accepted as input.
+ */
+public final class ScheduleInitialState {
+
+  private final boolean paused;
+  private final String pauseReason;
+  private final String pausedBy;
+
+  public ScheduleInitialState(boolean paused, String pauseReason, String pausedBy) {
+    this.paused = paused;
+    this.pauseReason = pauseReason;
+    this.pausedBy = pausedBy;
+  }
+
+  /** Whether to create the schedule in the paused state. */
+  public boolean isPaused() {
+    return paused;
+  }
+
+  /**
+   * Human-readable reason for the initial pause. May be {@code null} when {@link #isPaused()} is
+   * {@code false}.
+   */
+  public String getPauseReason() {
+    return pauseReason;
+  }
+
+  /**
+   * Identity of the actor initiating the pause. May be {@code null} when {@link #isPaused()} is
+   * {@code false}.
+   */
+  public String getPausedBy() {
+    return pausedBy;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ScheduleInitialState)) return false;
+    ScheduleInitialState that = (ScheduleInitialState) o;
+    return paused == that.paused
+        && Objects.equals(pauseReason, that.pauseReason)
+        && Objects.equals(pausedBy, that.pausedBy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(paused, pauseReason, pausedBy);
+  }
+
+  @Override
+  public String toString() {
+    return "ScheduleInitialState{"
+        + "paused="
+        + paused
+        + ", pauseReason='"
+        + pauseReason
+        + "', pausedBy='"
+        + pausedBy
+        + "'}";
+  }
+}

--- a/src/main/java/com/uber/cadence/client/schedule/ScheduleInitialState.java
+++ b/src/main/java/com/uber/cadence/client/schedule/ScheduleInitialState.java
@@ -28,7 +28,15 @@ public final class ScheduleInitialState {
   private final String pauseReason;
   private final String pausedBy;
 
+  /**
+   * @throws IllegalArgumentException if {@code pauseReason} or {@code pausedBy} is non-null but
+   *     {@code paused} is {@code false} — those fields are only meaningful when paused.
+   */
   public ScheduleInitialState(boolean paused, String pauseReason, String pausedBy) {
+    if (!paused && (pauseReason != null || pausedBy != null)) {
+      throw new IllegalArgumentException(
+          "pauseReason and pausedBy are only meaningful when paused=true");
+    }
     this.paused = paused;
     this.pauseReason = pauseReason;
     this.pausedBy = pausedBy;
@@ -39,18 +47,12 @@ public final class ScheduleInitialState {
     return paused;
   }
 
-  /**
-   * Human-readable reason for the initial pause. May be {@code null} when {@link #isPaused()} is
-   * {@code false}.
-   */
+  /** Human-readable reason for the initial pause. Only set when {@link #isPaused()} is true. */
   public String getPauseReason() {
     return pauseReason;
   }
 
-  /**
-   * Identity of the actor initiating the pause. May be {@code null} when {@link #isPaused()} is
-   * {@code false}.
-   */
+  /** Identity of the actor initiating the pause. Only set when {@link #isPaused()} is true. */
   public String getPausedBy() {
     return pausedBy;
   }

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/mappers/RequestMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/mappers/RequestMapper.java
@@ -45,6 +45,7 @@ import static com.uber.cadence.internal.compatibility.proto.mappers.TypeMapper.r
 import static com.uber.cadence.internal.compatibility.proto.mappers.TypeMapper.scheduleAction;
 import static com.uber.cadence.internal.compatibility.proto.mappers.TypeMapper.schedulePolicies;
 import static com.uber.cadence.internal.compatibility.proto.mappers.TypeMapper.scheduleSpec;
+import static com.uber.cadence.internal.compatibility.proto.mappers.TypeMapper.scheduleState;
 import static com.uber.cadence.internal.compatibility.proto.mappers.TypeMapper.searchAttributes;
 import static com.uber.cadence.internal.compatibility.proto.mappers.TypeMapper.startTimeFilter;
 import static com.uber.cadence.internal.compatibility.proto.mappers.TypeMapper.statusFilter;
@@ -1033,6 +1034,7 @@ public class RequestMapper {
     if (t.getMemo() != null) b.setMemo(memo(t.getMemo()));
     if (t.getSearchAttributes() != null)
       b.setSearchAttributes(searchAttributes(t.getSearchAttributes()));
+    if (t.getState() != null) b.setState(scheduleState(t.getState()));
     return b.build();
   }
 

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/mappers/TypeMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/mappers/TypeMapper.java
@@ -1197,6 +1197,16 @@ class TypeMapper {
     return res;
   }
 
+  static SchedulePauseInfo schedulePauseInfo(com.uber.cadence.SchedulePauseInfo t) {
+    if (t == null) {
+      return SchedulePauseInfo.getDefaultInstance();
+    }
+    return SchedulePauseInfo.newBuilder()
+        .setReason(Helpers.nullToEmpty(t.getReason()))
+        .setPausedBy(Helpers.nullToEmpty(t.getPausedBy()))
+        .build();
+  }
+
   static com.uber.cadence.ScheduleState scheduleState(ScheduleState t) {
     if (t == null || t == ScheduleState.getDefaultInstance()) {
       return null;
@@ -1205,6 +1215,15 @@ class TypeMapper {
     res.setPaused(t.getPaused());
     res.setPauseInfo(schedulePauseInfo(t.getPauseInfo()));
     return res;
+  }
+
+  static ScheduleState scheduleState(com.uber.cadence.ScheduleState t) {
+    if (t == null) {
+      return ScheduleState.getDefaultInstance();
+    }
+    ScheduleState.Builder b = ScheduleState.newBuilder().setPaused(t.isPaused());
+    if (t.getPauseInfo() != null) b.setPauseInfo(schedulePauseInfo(t.getPauseInfo()));
+    return b.build();
   }
 
   static com.uber.cadence.BackfillInfo backfillInfo(BackfillInfo t) {

--- a/src/main/java/com/uber/cadence/internal/sync/ScheduleClientImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ScheduleClientImpl.java
@@ -45,6 +45,7 @@ import com.uber.cadence.client.schedule.ScheduleAction;
 import com.uber.cadence.client.schedule.ScheduleCatchUpPolicy;
 import com.uber.cadence.client.schedule.ScheduleDescription;
 import com.uber.cadence.client.schedule.ScheduleInfo;
+import com.uber.cadence.client.schedule.ScheduleInitialState;
 import com.uber.cadence.client.schedule.ScheduleOverlapPolicy;
 import com.uber.cadence.client.schedule.SchedulePolicies;
 import com.uber.cadence.client.schedule.ScheduleSpec;
@@ -80,12 +81,25 @@ final class ScheduleClientImpl implements ScheduleClient {
   @Override
   public CompletableFuture<CreateScheduleResponse> createSchedule(
       String scheduleId, ScheduleSpec spec, ScheduleAction action, SchedulePolicies policies) {
+    return createSchedule(scheduleId, spec, action, policies, null);
+  }
+
+  @Override
+  public CompletableFuture<CreateScheduleResponse> createSchedule(
+      String scheduleId,
+      ScheduleSpec spec,
+      ScheduleAction action,
+      SchedulePolicies policies,
+      ScheduleInitialState initialState) {
     try {
       CreateScheduleRequest request =
           new CreateScheduleRequest()
               .setSpec(toThriftSpec(spec))
               .setAction(toThriftAction(action))
               .setPolicies(toThriftPolicies(policies));
+      if (initialState != null) {
+        request.setState(toThriftInitialState(initialState));
+      }
       return createSchedule(scheduleId, request);
     } catch (Exception e) {
       CompletableFuture<CreateScheduleResponse> f = new CompletableFuture<>();
@@ -293,6 +307,17 @@ final class ScheduleClientImpl implements ScheduleClient {
     }
     if (p.getCatchUpWindow() != null) {
       t.setCatchUpWindowInSeconds((int) p.getCatchUpWindow().getSeconds());
+    }
+    return t;
+  }
+
+  private static com.uber.cadence.ScheduleState toThriftInitialState(ScheduleInitialState s) {
+    com.uber.cadence.ScheduleState t = new com.uber.cadence.ScheduleState().setPaused(s.isPaused());
+    if (s.isPaused() && (s.getPauseReason() != null || s.getPausedBy() != null)) {
+      com.uber.cadence.SchedulePauseInfo pi = new com.uber.cadence.SchedulePauseInfo();
+      if (s.getPauseReason() != null) pi.setReason(s.getPauseReason());
+      if (s.getPausedBy() != null) pi.setPausedBy(s.getPausedBy());
+      t.setPauseInfo(pi);
     }
     return t;
   }

--- a/src/test/java/com/uber/cadence/client/schedule/ScheduleTypesTest.java
+++ b/src/test/java/com/uber/cadence/client/schedule/ScheduleTypesTest.java
@@ -308,6 +308,48 @@ public class ScheduleTypesTest {
   }
 
   @Test
+  public void scheduleInitialState_getters() {
+    ScheduleInitialState s = new ScheduleInitialState(true, "deploying", "ci-bot");
+    assertTrue(s.isPaused());
+    assertEquals("deploying", s.getPauseReason());
+    assertEquals("ci-bot", s.getPausedBy());
+  }
+
+  @Test
+  public void scheduleInitialState_equals() {
+    ScheduleInitialState a = new ScheduleInitialState(true, "reason", "user");
+    ScheduleInitialState b = new ScheduleInitialState(true, "reason", "user");
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  public void scheduleInitialState_notEqualOnDifferentPaused() {
+    assertNotEquals(
+        new ScheduleInitialState(true, null, null), new ScheduleInitialState(false, null, null));
+  }
+
+  @Test
+  public void scheduleInitialState_notEqualOnDifferentReason() {
+    assertNotEquals(
+        new ScheduleInitialState(true, "a", null), new ScheduleInitialState(true, "b", null));
+  }
+
+  @Test
+  public void scheduleInitialState_notEqualOnDifferentPausedBy() {
+    assertNotEquals(
+        new ScheduleInitialState(true, null, "x"), new ScheduleInitialState(true, null, "y"));
+  }
+
+  @Test
+  public void scheduleInitialState_toString() {
+    String s = new ScheduleInitialState(true, "deploy", "ci").toString();
+    assertTrue(s.contains("paused=true"));
+    assertTrue(s.contains("deploy"));
+    assertTrue(s.contains("ci"));
+  }
+
+  @Test
   public void scheduleState_getters() {
     Instant pausedAt = Instant.ofEpochSecond(500);
     ScheduleState state = new ScheduleState(true, "maintenance", pausedAt, "ops-team");

--- a/src/test/java/com/uber/cadence/client/schedule/ScheduleTypesTest.java
+++ b/src/test/java/com/uber/cadence/client/schedule/ScheduleTypesTest.java
@@ -341,6 +341,16 @@ public class ScheduleTypesTest {
         new ScheduleInitialState(true, null, "x"), new ScheduleInitialState(true, null, "y"));
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void scheduleInitialState_rejectsPauseReasonWhenNotPaused() {
+    new ScheduleInitialState(false, "reason", null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void scheduleInitialState_rejectsPausedByWhenNotPaused() {
+    new ScheduleInitialState(false, null, "user");
+  }
+
   @Test
   public void scheduleInitialState_toString() {
     String s = new ScheduleInitialState(true, "deploy", "ci").toString();

--- a/src/test/java/com/uber/cadence/internal/compatibility/proto/mappers/ScheduleTypeMapperTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/proto/mappers/ScheduleTypeMapperTest.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package com.uber.cadence.internal.compatibility.proto.mappers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.uber.cadence.api.v1.SchedulePauseInfo;
+import com.uber.cadence.api.v1.ScheduleState;
+import org.junit.Test;
+
+public class ScheduleTypeMapperTest {
+
+  // --- schedulePauseInfo(thrift→proto) ---
+
+  @Test
+  public void schedulePauseInfo_null_returnsDefault() {
+    assertEquals(
+        SchedulePauseInfo.getDefaultInstance(),
+        TypeMapper.schedulePauseInfo((com.uber.cadence.SchedulePauseInfo) null));
+  }
+
+  @Test
+  public void schedulePauseInfo_setsReasonAndPausedBy() {
+    com.uber.cadence.SchedulePauseInfo t = new com.uber.cadence.SchedulePauseInfo();
+    t.setReason("deploy");
+    t.setPausedBy("ci");
+
+    SchedulePauseInfo proto = TypeMapper.schedulePauseInfo(t);
+
+    assertEquals("deploy", proto.getReason());
+    assertEquals("ci", proto.getPausedBy());
+  }
+
+  // --- scheduleState(thrift→proto) ---
+
+  @Test
+  public void scheduleState_null_returnsDefault() {
+    assertEquals(
+        ScheduleState.getDefaultInstance(),
+        TypeMapper.scheduleState((com.uber.cadence.ScheduleState) null));
+  }
+
+  @Test
+  public void scheduleState_pausedNoPauseInfo_noPauseInfoInProto() {
+    com.uber.cadence.ScheduleState t = new com.uber.cadence.ScheduleState().setPaused(true);
+
+    ScheduleState proto = TypeMapper.scheduleState(t);
+
+    assertTrue(proto.getPaused());
+    assertFalse(proto.hasPauseInfo());
+  }
+
+  @Test
+  public void scheduleState_withPauseInfo_populatesPauseInfo() {
+    com.uber.cadence.SchedulePauseInfo pi = new com.uber.cadence.SchedulePauseInfo();
+    pi.setReason("maintenance");
+    com.uber.cadence.ScheduleState t =
+        new com.uber.cadence.ScheduleState().setPaused(true).setPauseInfo(pi);
+
+    ScheduleState proto = TypeMapper.scheduleState(t);
+
+    assertTrue(proto.getPaused());
+    assertEquals("maintenance", proto.getPauseInfo().getReason());
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/sync/ScheduleClientImplTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/ScheduleClientImplTest.java
@@ -402,6 +402,44 @@ public class ScheduleClientImplTest {
     assertNull(captor.getValue().getState());
   }
 
+  @Test
+  public void createSchedule_initialState_pausedWithReasonOnly() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
+
+    client
+        .createSchedule(
+            SCHEDULE_ID,
+            null,
+            minimalAction(),
+            null,
+            new ScheduleInitialState(true, "reason", null))
+        .join();
+
+    CreateScheduleRequest req = captor.getValue();
+    assertNotNull(req.getState().getPauseInfo());
+    assertEquals("reason", req.getState().getPauseInfo().getReason());
+    assertNull(req.getState().getPauseInfo().getPausedBy());
+  }
+
+  @Test
+  public void createSchedule_initialState_pausedWithPausedByOnly() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
+
+    client
+        .createSchedule(
+            SCHEDULE_ID, null, minimalAction(), null, new ScheduleInitialState(true, null, "ci"))
+        .join();
+
+    CreateScheduleRequest req = captor.getValue();
+    assertNotNull(req.getState().getPauseInfo());
+    assertNull(req.getState().getPauseInfo().getReason());
+    assertEquals("ci", req.getState().getPauseInfo().getPausedBy());
+  }
+
   // --- null handling ---
 
   @Test

--- a/src/test/java/com/uber/cadence/internal/sync/ScheduleClientImplTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/ScheduleClientImplTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -438,6 +439,28 @@ public class ScheduleClientImplTest {
     assertNotNull(req.getState().getPauseInfo());
     assertNull(req.getState().getPauseInfo().getReason());
     assertEquals("ci", req.getState().getPauseInfo().getPausedBy());
+  }
+
+  @Test
+  public void createScheduleRequest_stateSerializesToProto() {
+    com.uber.cadence.SchedulePauseInfo pi = new com.uber.cadence.SchedulePauseInfo();
+    pi.setReason("deploying");
+    pi.setPausedBy("ci-bot");
+    com.uber.cadence.ScheduleState thriftState =
+        new com.uber.cadence.ScheduleState().setPaused(true).setPauseInfo(pi);
+    com.uber.cadence.CreateScheduleRequest thrift =
+        new com.uber.cadence.CreateScheduleRequest()
+            .setDomain(DOMAIN)
+            .setScheduleId(SCHEDULE_ID)
+            .setState(thriftState);
+
+    com.uber.cadence.api.v1.CreateScheduleRequest proto =
+        com.uber.cadence.internal.compatibility.proto.mappers.RequestMapper.createScheduleRequest(
+            thrift);
+
+    assertTrue(proto.getState().getPaused());
+    assertEquals("deploying", proto.getState().getPauseInfo().getReason());
+    assertEquals("ci-bot", proto.getState().getPauseInfo().getPausedBy());
   }
 
   // --- null handling ---

--- a/src/test/java/com/uber/cadence/internal/sync/ScheduleClientImplTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/ScheduleClientImplTest.java
@@ -29,6 +29,7 @@ import com.uber.cadence.UpdateScheduleRequest;
 import com.uber.cadence.UpdateScheduleResponse;
 import com.uber.cadence.client.schedule.ScheduleAction;
 import com.uber.cadence.client.schedule.ScheduleCatchUpPolicy;
+import com.uber.cadence.client.schedule.ScheduleInitialState;
 import com.uber.cadence.client.schedule.ScheduleOverlapPolicy;
 import com.uber.cadence.client.schedule.SchedulePolicies;
 import com.uber.cadence.client.schedule.ScheduleSpec;
@@ -341,6 +342,64 @@ public class ScheduleClientImplTest {
     assertEquals("0 * * * *", req.getSpec().getCronExpression());
     assertEquals(
         com.uber.cadence.ScheduleOverlapPolicy.CONCURRENT, req.getPolicies().getOverlapPolicy());
+  }
+
+  // --- initialState ---
+
+  @Test
+  public void createSchedule_initialState_pausedWithReasonAndPausedBy() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
+
+    ScheduleInitialState initialState = new ScheduleInitialState(true, "deploying", "ci-bot");
+    client.createSchedule(SCHEDULE_ID, null, minimalAction(), null, initialState).join();
+
+    CreateScheduleRequest req = captor.getValue();
+    assertNotNull(req.getState());
+    assertEquals(true, req.getState().isPaused());
+    assertNotNull(req.getState().getPauseInfo());
+    assertEquals("deploying", req.getState().getPauseInfo().getReason());
+    assertEquals("ci-bot", req.getState().getPauseInfo().getPausedBy());
+  }
+
+  @Test
+  public void createSchedule_initialState_pausedNoPauseInfo() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
+
+    client
+        .createSchedule(
+            SCHEDULE_ID, null, minimalAction(), null, new ScheduleInitialState(true, null, null))
+        .join();
+
+    CreateScheduleRequest req = captor.getValue();
+    assertNotNull(req.getState());
+    assertEquals(true, req.getState().isPaused());
+    assertNull(req.getState().getPauseInfo());
+  }
+
+  @Test
+  public void createSchedule_initialState_null_sendsNoState() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
+
+    client.createSchedule(SCHEDULE_ID, null, minimalAction(), null, null).join();
+
+    assertNull(captor.getValue().getState());
+  }
+
+  @Test
+  public void createSchedule_fourArg_sendsNoState() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
+
+    client.createSchedule(SCHEDULE_ID, null, minimalAction(), null).join();
+
+    assertNull(captor.getValue().getState());
   }
 
   // --- null handling ---

--- a/src/test/java/com/uber/cadence/internal/sync/ScheduleClientImplTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/ScheduleClientImplTest.java
@@ -16,6 +16,7 @@ package com.uber.cadence.internal.sync;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -439,6 +440,18 @@ public class ScheduleClientImplTest {
     assertNotNull(req.getState().getPauseInfo());
     assertNull(req.getState().getPauseInfo().getReason());
     assertEquals("ci", req.getState().getPauseInfo().getPausedBy());
+  }
+
+  @Test
+  public void createScheduleRequest_nullState_producesNoStateInProto() {
+    com.uber.cadence.CreateScheduleRequest thrift =
+        new com.uber.cadence.CreateScheduleRequest().setDomain(DOMAIN).setScheduleId(SCHEDULE_ID);
+
+    com.uber.cadence.api.v1.CreateScheduleRequest proto =
+        com.uber.cadence.internal.compatibility.proto.mappers.RequestMapper.createScheduleRequest(
+            thrift);
+
+    assertFalse(proto.hasState());
   }
 
   @Test


### PR DESCRIPTION
## What

Adds `ScheduleInitialState` and a five-arg `createSchedule()` overload so callers can create a schedule that starts already paused, without a subsequent `pauseSchedule` call.

## Why

Previously, creating a paused schedule required two round-trips: create, then pause. The server already supports `state` in `CreateScheduleRequest` (added in cadence-idl [#276](https://github.com/uber/cadence-idl/pull/276)), so this wires it end-to-end in the Java client.

## Changes

- `ScheduleInitialState`: new input-only value type (`paused`, `pauseReason`, `pausedBy`). `pausedAt` is intentionally omitted, it is server-populated.
- `ScheduleClient`: new five-arg `createSchedule(scheduleId, spec, action, policies, initialState)` overload. The existing four-arg overload delegates to it with `null`.
- `ScheduleClientImpl`: implementation + `toThriftInitialState` mapper.
- `TypeMapper`: thrift→proto overloads for `schedulePauseInfo` and `scheduleState` (the existing ones were proto→thrift response-only).
- `RequestMapper.createScheduleRequest`: wires `state` into the proto builder so it is not dropped on the gRPC path.

## Test plan

- `ScheduleInitialState`: getters, equals/hashCode, toString, not-equal cases (`ScheduleTypesTest`)
- `createSchedule` wiring: paused with reason+pausedBy, paused with only reason, paused with only pausedBy, paused with no pause info, null initialState, four-arg overload (`ScheduleClientImplTest`)
- `RequestMapper.createScheduleRequest`: verifies state and pauseInfo survive thrift→proto conversion (`ScheduleClientImplTest.createScheduleRequest_stateSerializesToProto`)