### PR TITLE
chore: bump cadence-idl to d6d4d81 and adapt v3 to the new IDL

### DIFF
--- a/src/main/java/com/uber/cadence/internal/common/FeatureFlagsHeader.java
+++ b/src/main/java/com/uber/cadence/internal/common/FeatureFlagsHeader.java
@@ -17,26 +17,33 @@
 
 package com.uber.cadence.internal.common;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
 import com.uber.cadence.FeatureFlags;
-import java.lang.reflect.Modifier;
 
 /** Serializes {@link FeatureFlags} into the value of the cadence-client-feature-flags header. */
 public final class FeatureFlagsHeader {
 
   // The server deserializes this header with a protobuf JSON unmarshaller that fails on any field
-  // it doesn't know, and silently falls back to all flags disabled when it does. Thrift declares
-  // the IDL fields public and keeps its own bookkeeping, such as __isset_bitfield, private, so
-  // excluding private fields leaves exactly the fields the server expects. Field names are sent as
-  // Thrift declares them because the proto IDL pins json_name to those names.
-  private static final Gson GSON =
-      new GsonBuilder()
-          .excludeFieldsWithModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.TRANSIENT)
-          .create();
+  // it doesn't know, and silently falls back to all flags disabled when it does. The accepted
+  // field names are therefore defined by the api.v1.FeatureFlags proto message (including its
+  // json_name pins), not by the Thrift struct's field names. Serializing through the generated
+  // proto message with JsonFormat keeps the header aligned with that contract by construction.
+  private static final JsonFormat.Printer PRINTER =
+      JsonFormat.printer().includingDefaultValueFields().omittingInsignificantWhitespace();
 
   public static String serialize(FeatureFlags featureFlags) {
-    return GSON.toJson(featureFlags);
+    com.uber.cadence.api.v1.FeatureFlags proto =
+        com.uber.cadence.api.v1.FeatureFlags.newBuilder()
+            .setWorkflowExecutionAlreadyCompletedErrorEnabled(
+                featureFlags.isWorkflowExecutionAlreadyCompletedErrorEnabled())
+            .setAutoforwardingEnabled(featureFlags.isAutoForwardingEnabled())
+            .build();
+    try {
+      return PRINTER.print(proto);
+    } catch (InvalidProtocolBufferException e) {
+      throw new IllegalStateException("failed to serialize feature flags header", e);
+    }
   }
 
   private FeatureFlagsHeader() {}

--- a/src/main/java/com/uber/cadence/internal/compatibility/Thrift2ProtoAdapter.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/Thrift2ProtoAdapter.java
@@ -18,15 +18,25 @@ package com.uber.cadence.internal.compatibility;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.uber.cadence.AccessDeniedError;
+import com.uber.cadence.BackfillScheduleRequest;
+import com.uber.cadence.BackfillScheduleResponse;
 import com.uber.cadence.BadRequestError;
 import com.uber.cadence.CancellationAlreadyRequestedError;
 import com.uber.cadence.ClientVersionNotSupportedError;
 import com.uber.cadence.ClusterInfo;
 import com.uber.cadence.CountWorkflowExecutionsRequest;
 import com.uber.cadence.CountWorkflowExecutionsResponse;
+import com.uber.cadence.CreateScheduleRequest;
+import com.uber.cadence.CreateScheduleResponse;
+import com.uber.cadence.DeleteDomainRequest;
+import com.uber.cadence.DeleteScheduleRequest;
+import com.uber.cadence.DeleteScheduleResponse;
 import com.uber.cadence.DeprecateDomainRequest;
 import com.uber.cadence.DescribeDomainRequest;
 import com.uber.cadence.DescribeDomainResponse;
+import com.uber.cadence.DescribeScheduleRequest;
+import com.uber.cadence.DescribeScheduleResponse;
 import com.uber.cadence.DescribeTaskListRequest;
 import com.uber.cadence.DescribeTaskListResponse;
 import com.uber.cadence.DescribeWorkflowExecutionRequest;
@@ -36,6 +46,8 @@ import com.uber.cadence.DiagnoseWorkflowExecutionResponse;
 import com.uber.cadence.DomainAlreadyExistsError;
 import com.uber.cadence.DomainNotActiveError;
 import com.uber.cadence.EntityNotExistsError;
+import com.uber.cadence.FailoverDomainRequest;
+import com.uber.cadence.FailoverDomainResponse;
 import com.uber.cadence.GetSearchAttributesResponse;
 import com.uber.cadence.GetTaskListsByDomainRequest;
 import com.uber.cadence.GetTaskListsByDomainResponse;
@@ -49,12 +61,18 @@ import com.uber.cadence.ListClosedWorkflowExecutionsRequest;
 import com.uber.cadence.ListClosedWorkflowExecutionsResponse;
 import com.uber.cadence.ListDomainsRequest;
 import com.uber.cadence.ListDomainsResponse;
+import com.uber.cadence.ListFailoverHistoryRequest;
+import com.uber.cadence.ListFailoverHistoryResponse;
 import com.uber.cadence.ListOpenWorkflowExecutionsRequest;
 import com.uber.cadence.ListOpenWorkflowExecutionsResponse;
+import com.uber.cadence.ListSchedulesRequest;
+import com.uber.cadence.ListSchedulesResponse;
 import com.uber.cadence.ListTaskListPartitionsRequest;
 import com.uber.cadence.ListTaskListPartitionsResponse;
 import com.uber.cadence.ListWorkflowExecutionsRequest;
 import com.uber.cadence.ListWorkflowExecutionsResponse;
+import com.uber.cadence.PauseScheduleRequest;
+import com.uber.cadence.PauseScheduleResponse;
 import com.uber.cadence.PollForActivityTaskRequest;
 import com.uber.cadence.PollForActivityTaskResponse;
 import com.uber.cadence.PollForDecisionTaskRequest;
@@ -94,8 +112,12 @@ import com.uber.cadence.StartWorkflowExecutionAsyncResponse;
 import com.uber.cadence.StartWorkflowExecutionRequest;
 import com.uber.cadence.StartWorkflowExecutionResponse;
 import com.uber.cadence.TerminateWorkflowExecutionRequest;
+import com.uber.cadence.UnpauseScheduleRequest;
+import com.uber.cadence.UnpauseScheduleResponse;
 import com.uber.cadence.UpdateDomainRequest;
 import com.uber.cadence.UpdateDomainResponse;
+import com.uber.cadence.UpdateScheduleRequest;
+import com.uber.cadence.UpdateScheduleResponse;
 import com.uber.cadence.WorkflowExecutionAlreadyCompletedError;
 import com.uber.cadence.WorkflowExecutionAlreadyStartedError;
 import com.uber.cadence.api.v1.GetSearchAttributesRequest;
@@ -1309,6 +1331,154 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
       AsyncMethodCallback resultHandler,
       Long timeoutInMillis)
       throws TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public CreateScheduleResponse CreateSchedule(CreateScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, AccessDeniedError, TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public void CreateSchedule(CreateScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public DescribeScheduleResponse DescribeSchedule(DescribeScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, QueryFailedError,
+          LimitExceededError, AccessDeniedError, TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public void DescribeSchedule(DescribeScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public UpdateScheduleResponse UpdateSchedule(UpdateScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public void UpdateSchedule(UpdateScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public DeleteScheduleResponse DeleteSchedule(DeleteScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public void DeleteSchedule(DeleteScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public PauseScheduleResponse PauseSchedule(PauseScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public void PauseSchedule(PauseScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public UnpauseScheduleResponse UnpauseSchedule(UnpauseScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public void UnpauseSchedule(UnpauseScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public BackfillScheduleResponse BackfillSchedule(BackfillScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public void BackfillSchedule(BackfillScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public ListSchedulesResponse ListSchedules(ListSchedulesRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public void ListSchedules(ListSchedulesRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the v3 client");
+  }
+
+  @Override
+  public ListFailoverHistoryResponse ListFailoverHistory(ListFailoverHistoryRequest listRequest)
+      throws BadRequestError, ServiceBusyError, ClientVersionNotSupportedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void ListFailoverHistory(
+      ListFailoverHistoryRequest listRequest, AsyncMethodCallback resultHandler) throws TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void DeleteDomain(DeleteDomainRequest deleteRequest)
+      throws BadRequestError, ServiceBusyError, ClientVersionNotSupportedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void DeleteDomain(DeleteDomainRequest deleteRequest, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public FailoverDomainResponse FailoverDomain(FailoverDomainRequest failoverRequest)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          ClientVersionNotSupportedError, AccessDeniedError, TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void FailoverDomain(
+      FailoverDomainRequest failoverRequest, AsyncMethodCallback resultHandler) throws TException {
     throw new UnsupportedOperationException("not implemented");
   }
 

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/EnumMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/EnumMapper.java
@@ -69,6 +69,8 @@ public final class EnumMapper {
         return TaskListKind.TASK_LIST_KIND_NORMAL;
       case STICKY:
         return TaskListKind.TASK_LIST_KIND_STICKY;
+      case EPHEMERAL:
+        return TaskListKind.TASK_LIST_KIND_EPHEMERAL;
     }
     throw new IllegalArgumentException("unexpected enum value");
   }

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/TypeMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/TypeMapper.java
@@ -146,6 +146,9 @@ class TypeMapper {
     if (t.getKind() != null) {
       builder.setKind(taskListKind(t.getKind()));
     }
+    if (t.getBaseName() != null) {
+      builder.setBaseName(t.getBaseName());
+    }
     return builder.build();
   }
 

--- a/src/main/java/com/uber/cadence/internal/compatibility/thrift/EnumMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/thrift/EnumMapper.java
@@ -48,6 +48,8 @@ public final class EnumMapper {
         return TaskListKind.NORMAL;
       case TASK_LIST_KIND_STICKY:
         return TaskListKind.STICKY;
+      case TASK_LIST_KIND_EPHEMERAL:
+        return TaskListKind.EPHEMERAL;
     }
     throw new IllegalArgumentException("unexpected enum value");
   }

--- a/src/main/java/com/uber/cadence/internal/compatibility/thrift/TypeMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/thrift/TypeMapper.java
@@ -149,6 +149,7 @@ class TypeMapper {
     TaskList taskList = new TaskList();
     taskList.setName(t.getName());
     taskList.setKind(taskListKind(t.getKind()));
+    taskList.setBaseName(t.getBaseName());
     return taskList;
   }
 

--- a/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
@@ -1035,5 +1035,155 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
     public void close() {
       impl.close();
     }
+
+    @Override
+    public CreateScheduleResponse CreateSchedule(CreateScheduleRequest request)
+        throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+            LimitExceededError, AccessDeniedError, TException {
+      return impl.CreateSchedule(request);
+    }
+
+    @Override
+    public void CreateSchedule(CreateScheduleRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.CreateSchedule(request, resultHandler);
+    }
+
+    @Override
+    public DescribeScheduleResponse DescribeSchedule(DescribeScheduleRequest request)
+        throws BadRequestError, EntityNotExistsError, ServiceBusyError, QueryFailedError,
+            LimitExceededError, AccessDeniedError, TException {
+      return impl.DescribeSchedule(request);
+    }
+
+    @Override
+    public void DescribeSchedule(DescribeScheduleRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.DescribeSchedule(request, resultHandler);
+    }
+
+    @Override
+    public UpdateScheduleResponse UpdateSchedule(UpdateScheduleRequest request)
+        throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+            LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+            TException {
+      return impl.UpdateSchedule(request);
+    }
+
+    @Override
+    public void UpdateSchedule(UpdateScheduleRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.UpdateSchedule(request, resultHandler);
+    }
+
+    @Override
+    public DeleteScheduleResponse DeleteSchedule(DeleteScheduleRequest request)
+        throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+            LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+            TException {
+      return impl.DeleteSchedule(request);
+    }
+
+    @Override
+    public void DeleteSchedule(DeleteScheduleRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.DeleteSchedule(request, resultHandler);
+    }
+
+    @Override
+    public PauseScheduleResponse PauseSchedule(PauseScheduleRequest request)
+        throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+            LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+            TException {
+      return impl.PauseSchedule(request);
+    }
+
+    @Override
+    public void PauseSchedule(PauseScheduleRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.PauseSchedule(request, resultHandler);
+    }
+
+    @Override
+    public UnpauseScheduleResponse UnpauseSchedule(UnpauseScheduleRequest request)
+        throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+            LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+            TException {
+      return impl.UnpauseSchedule(request);
+    }
+
+    @Override
+    public void UnpauseSchedule(UnpauseScheduleRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.UnpauseSchedule(request, resultHandler);
+    }
+
+    @Override
+    public BackfillScheduleResponse BackfillSchedule(BackfillScheduleRequest request)
+        throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+            LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+            TException {
+      return impl.BackfillSchedule(request);
+    }
+
+    @Override
+    public void BackfillSchedule(BackfillScheduleRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.BackfillSchedule(request, resultHandler);
+    }
+
+    @Override
+    public ListSchedulesResponse ListSchedules(ListSchedulesRequest request)
+        throws BadRequestError, EntityNotExistsError, ServiceBusyError, AccessDeniedError,
+            TException {
+      return impl.ListSchedules(request);
+    }
+
+    @Override
+    public void ListSchedules(ListSchedulesRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.ListSchedules(request, resultHandler);
+    }
+
+    @Override
+    public ListFailoverHistoryResponse ListFailoverHistory(ListFailoverHistoryRequest listRequest)
+        throws BadRequestError, ServiceBusyError, ClientVersionNotSupportedError, AccessDeniedError,
+            TException {
+      return impl.ListFailoverHistory(listRequest);
+    }
+
+    @Override
+    public void ListFailoverHistory(
+        ListFailoverHistoryRequest listRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.ListFailoverHistory(listRequest, resultHandler);
+    }
+
+    @Override
+    public void DeleteDomain(DeleteDomainRequest deleteRequest)
+        throws BadRequestError, ServiceBusyError, ClientVersionNotSupportedError, AccessDeniedError,
+            TException {
+      impl.DeleteDomain(deleteRequest);
+    }
+
+    @Override
+    public void DeleteDomain(DeleteDomainRequest deleteRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.DeleteDomain(deleteRequest, resultHandler);
+    }
+
+    @Override
+    public FailoverDomainResponse FailoverDomain(FailoverDomainRequest failoverRequest)
+        throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+            ClientVersionNotSupportedError, AccessDeniedError, TException {
+      return impl.FailoverDomain(failoverRequest);
+    }
+
+    @Override
+    public void FailoverDomain(
+        FailoverDomainRequest failoverRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.FailoverDomain(failoverRequest, resultHandler);
+    }
   }
 }

--- a/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
@@ -17,14 +17,23 @@
 
 package com.uber.cadence.internal.sync;
 
+import com.uber.cadence.BackfillScheduleRequest;
+import com.uber.cadence.BackfillScheduleResponse;
 import com.uber.cadence.BadRequestError;
 import com.uber.cadence.ClientVersionNotSupportedError;
 import com.uber.cadence.ClusterInfo;
 import com.uber.cadence.CountWorkflowExecutionsRequest;
 import com.uber.cadence.CountWorkflowExecutionsResponse;
+import com.uber.cadence.CreateScheduleRequest;
+import com.uber.cadence.CreateScheduleResponse;
+import com.uber.cadence.DeleteDomainRequest;
+import com.uber.cadence.DeleteScheduleRequest;
+import com.uber.cadence.DeleteScheduleResponse;
 import com.uber.cadence.DeprecateDomainRequest;
 import com.uber.cadence.DescribeDomainRequest;
 import com.uber.cadence.DescribeDomainResponse;
+import com.uber.cadence.DescribeScheduleRequest;
+import com.uber.cadence.DescribeScheduleResponse;
 import com.uber.cadence.DescribeTaskListRequest;
 import com.uber.cadence.DescribeTaskListResponse;
 import com.uber.cadence.DescribeWorkflowExecutionRequest;
@@ -34,6 +43,8 @@ import com.uber.cadence.DiagnoseWorkflowExecutionResponse;
 import com.uber.cadence.DomainAlreadyExistsError;
 import com.uber.cadence.DomainNotActiveError;
 import com.uber.cadence.EntityNotExistsError;
+import com.uber.cadence.FailoverDomainRequest;
+import com.uber.cadence.FailoverDomainResponse;
 import com.uber.cadence.GetSearchAttributesResponse;
 import com.uber.cadence.GetTaskListsByDomainRequest;
 import com.uber.cadence.GetTaskListsByDomainResponse;
@@ -47,12 +58,18 @@ import com.uber.cadence.ListClosedWorkflowExecutionsRequest;
 import com.uber.cadence.ListClosedWorkflowExecutionsResponse;
 import com.uber.cadence.ListDomainsRequest;
 import com.uber.cadence.ListDomainsResponse;
+import com.uber.cadence.ListFailoverHistoryRequest;
+import com.uber.cadence.ListFailoverHistoryResponse;
 import com.uber.cadence.ListOpenWorkflowExecutionsRequest;
 import com.uber.cadence.ListOpenWorkflowExecutionsResponse;
+import com.uber.cadence.ListSchedulesRequest;
+import com.uber.cadence.ListSchedulesResponse;
 import com.uber.cadence.ListTaskListPartitionsRequest;
 import com.uber.cadence.ListTaskListPartitionsResponse;
 import com.uber.cadence.ListWorkflowExecutionsRequest;
 import com.uber.cadence.ListWorkflowExecutionsResponse;
+import com.uber.cadence.PauseScheduleRequest;
+import com.uber.cadence.PauseScheduleResponse;
 import com.uber.cadence.PollForActivityTaskRequest;
 import com.uber.cadence.PollForActivityTaskResponse;
 import com.uber.cadence.PollForDecisionTaskRequest;
@@ -93,8 +110,12 @@ import com.uber.cadence.StartWorkflowExecutionAsyncResponse;
 import com.uber.cadence.StartWorkflowExecutionRequest;
 import com.uber.cadence.StartWorkflowExecutionResponse;
 import com.uber.cadence.TerminateWorkflowExecutionRequest;
+import com.uber.cadence.UnpauseScheduleRequest;
+import com.uber.cadence.UnpauseScheduleResponse;
 import com.uber.cadence.UpdateDomainRequest;
 import com.uber.cadence.UpdateDomainResponse;
+import com.uber.cadence.UpdateScheduleRequest;
+import com.uber.cadence.UpdateScheduleResponse;
 import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.WorkflowExecutionAlreadyCompletedError;
 import com.uber.cadence.WorkflowExecutionAlreadyStartedError;
@@ -943,6 +964,134 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
 
     public void sleep(Duration duration) {
       impl.sleep(duration);
+    }
+
+    @Override
+    public CreateScheduleResponse CreateSchedule(CreateScheduleRequest request) throws TException {
+      return impl.CreateSchedule(request);
+    }
+
+    @Override
+    public void CreateSchedule(CreateScheduleRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.CreateSchedule(request, resultHandler);
+    }
+
+    @Override
+    public DescribeScheduleResponse DescribeSchedule(DescribeScheduleRequest request)
+        throws TException {
+      return impl.DescribeSchedule(request);
+    }
+
+    @Override
+    public void DescribeSchedule(DescribeScheduleRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.DescribeSchedule(request, resultHandler);
+    }
+
+    @Override
+    public UpdateScheduleResponse UpdateSchedule(UpdateScheduleRequest request) throws TException {
+      return impl.UpdateSchedule(request);
+    }
+
+    @Override
+    public void UpdateSchedule(UpdateScheduleRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.UpdateSchedule(request, resultHandler);
+    }
+
+    @Override
+    public DeleteScheduleResponse DeleteSchedule(DeleteScheduleRequest request) throws TException {
+      return impl.DeleteSchedule(request);
+    }
+
+    @Override
+    public void DeleteSchedule(DeleteScheduleRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.DeleteSchedule(request, resultHandler);
+    }
+
+    @Override
+    public PauseScheduleResponse PauseSchedule(PauseScheduleRequest request) throws TException {
+      return impl.PauseSchedule(request);
+    }
+
+    @Override
+    public void PauseSchedule(PauseScheduleRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.PauseSchedule(request, resultHandler);
+    }
+
+    @Override
+    public UnpauseScheduleResponse UnpauseSchedule(UnpauseScheduleRequest request)
+        throws TException {
+      return impl.UnpauseSchedule(request);
+    }
+
+    @Override
+    public void UnpauseSchedule(UnpauseScheduleRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.UnpauseSchedule(request, resultHandler);
+    }
+
+    @Override
+    public BackfillScheduleResponse BackfillSchedule(BackfillScheduleRequest request)
+        throws TException {
+      return impl.BackfillSchedule(request);
+    }
+
+    @Override
+    public void BackfillSchedule(BackfillScheduleRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.BackfillSchedule(request, resultHandler);
+    }
+
+    @Override
+    public ListSchedulesResponse ListSchedules(ListSchedulesRequest request) throws TException {
+      return impl.ListSchedules(request);
+    }
+
+    @Override
+    public void ListSchedules(ListSchedulesRequest request, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.ListSchedules(request, resultHandler);
+    }
+
+    @Override
+    public ListFailoverHistoryResponse ListFailoverHistory(ListFailoverHistoryRequest listRequest)
+        throws TException {
+      return impl.ListFailoverHistory(listRequest);
+    }
+
+    @Override
+    public void ListFailoverHistory(
+        ListFailoverHistoryRequest listRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.ListFailoverHistory(listRequest, resultHandler);
+    }
+
+    @Override
+    public void DeleteDomain(DeleteDomainRequest deleteRequest) throws TException {
+      impl.DeleteDomain(deleteRequest);
+    }
+
+    @Override
+    public void DeleteDomain(DeleteDomainRequest deleteRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.DeleteDomain(deleteRequest, resultHandler);
+    }
+
+    @Override
+    public FailoverDomainResponse FailoverDomain(FailoverDomainRequest failoverRequest)
+        throws TException {
+      return impl.FailoverDomain(failoverRequest);
+    }
+
+    @Override
+    public void FailoverDomain(
+        FailoverDomainRequest failoverRequest, AsyncMethodCallback resultHandler)
+        throws TException {
+      impl.FailoverDomain(failoverRequest, resultHandler);
     }
   }
 

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -113,6 +113,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -369,7 +370,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             return;
           }
           if (decision == null) {
-            throw new EntityNotExistsError("No outstanding decision");
+            throw new EntityNotExistsError("No outstanding decision", Collections.emptyList());
           }
           decision.action(StateMachines.Action.COMPLETE, ctx, request, 0);
           for (Decision d : decisions) {
@@ -658,7 +659,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
   private StateMachine<SignalExternalData> getSignal(String signalId) throws EntityNotExistsError {
     StateMachine<SignalExternalData> signal = externalSignals.get(signalId);
     if (signal == null) {
-      throw new EntityNotExistsError("unknown signalId: " + signalId);
+      throw new EntityNotExistsError("unknown signalId: " + signalId, Collections.emptyList());
     }
     return signal;
   }
@@ -1366,7 +1367,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             StateMachine<ActivityTaskData> activity = getActivity(activityId);
             if (timeoutType == TimeoutType.SCHEDULE_TO_START
                 && activity.getState() != StateMachines.State.INITIATED) {
-              throw new EntityNotExistsError("Not in INITIATED");
+              throw new EntityNotExistsError("Not in INITIATED", Collections.emptyList());
             }
             if (timeoutType == TimeoutType.HEARTBEAT) {
               // Deal with timers which are never cancelled
@@ -1374,7 +1375,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
                   TimeUnit.SECONDS.toMillis(
                       activity.getData().scheduledEvent.getHeartbeatTimeoutSeconds());
               if (clock.getAsLong() - activity.getData().lastHeartbeatTime < heartbeatTimeout) {
-                throw new EntityNotExistsError("Not heartbeat timeout");
+                throw new EntityNotExistsError("Not heartbeat timeout", Collections.emptyList());
               }
             }
             activity.action(StateMachines.Action.TIME_OUT, ctx, timeoutType, 0);
@@ -1542,7 +1543,8 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       throws EntityNotExistsError {
     CompletableFuture<QueryWorkflowResponse> result = queries.get(queryId.getQueryId());
     if (result == null) {
-      throw new EntityNotExistsError("Unknown query id: " + queryId.getQueryId());
+      throw new EntityNotExistsError(
+          "Unknown query id: " + queryId.getQueryId(), Collections.emptyList());
     }
     if (completeRequest.getCompletedType() == QueryTaskCompletedType.COMPLETED) {
       QueryWorkflowResponse response =
@@ -1594,7 +1596,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       throws EntityNotExistsError {
     StateMachine<ActivityTaskData> activity = activities.get(activityId);
     if (activity == null) {
-      throw new EntityNotExistsError("unknown activityId: " + activityId);
+      throw new EntityNotExistsError("unknown activityId: " + activityId, Collections.emptyList());
     }
     return activity;
   }

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
@@ -17,14 +17,24 @@
 
 package com.uber.cadence.internal.testservice;
 
+import com.uber.cadence.AccessDeniedError;
+import com.uber.cadence.BackfillScheduleRequest;
+import com.uber.cadence.BackfillScheduleResponse;
 import com.uber.cadence.BadRequestError;
 import com.uber.cadence.ClientVersionNotSupportedError;
 import com.uber.cadence.ClusterInfo;
 import com.uber.cadence.CountWorkflowExecutionsRequest;
 import com.uber.cadence.CountWorkflowExecutionsResponse;
+import com.uber.cadence.CreateScheduleRequest;
+import com.uber.cadence.CreateScheduleResponse;
+import com.uber.cadence.DeleteDomainRequest;
+import com.uber.cadence.DeleteScheduleRequest;
+import com.uber.cadence.DeleteScheduleResponse;
 import com.uber.cadence.DeprecateDomainRequest;
 import com.uber.cadence.DescribeDomainRequest;
 import com.uber.cadence.DescribeDomainResponse;
+import com.uber.cadence.DescribeScheduleRequest;
+import com.uber.cadence.DescribeScheduleResponse;
 import com.uber.cadence.DescribeTaskListRequest;
 import com.uber.cadence.DescribeTaskListResponse;
 import com.uber.cadence.DescribeWorkflowExecutionRequest;
@@ -34,6 +44,8 @@ import com.uber.cadence.DiagnoseWorkflowExecutionResponse;
 import com.uber.cadence.DomainAlreadyExistsError;
 import com.uber.cadence.DomainNotActiveError;
 import com.uber.cadence.EntityNotExistsError;
+import com.uber.cadence.FailoverDomainRequest;
+import com.uber.cadence.FailoverDomainResponse;
 import com.uber.cadence.GetSearchAttributesResponse;
 import com.uber.cadence.GetTaskListsByDomainRequest;
 import com.uber.cadence.GetTaskListsByDomainResponse;
@@ -47,12 +59,18 @@ import com.uber.cadence.ListClosedWorkflowExecutionsRequest;
 import com.uber.cadence.ListClosedWorkflowExecutionsResponse;
 import com.uber.cadence.ListDomainsRequest;
 import com.uber.cadence.ListDomainsResponse;
+import com.uber.cadence.ListFailoverHistoryRequest;
+import com.uber.cadence.ListFailoverHistoryResponse;
 import com.uber.cadence.ListOpenWorkflowExecutionsRequest;
 import com.uber.cadence.ListOpenWorkflowExecutionsResponse;
+import com.uber.cadence.ListSchedulesRequest;
+import com.uber.cadence.ListSchedulesResponse;
 import com.uber.cadence.ListTaskListPartitionsRequest;
 import com.uber.cadence.ListTaskListPartitionsResponse;
 import com.uber.cadence.ListWorkflowExecutionsRequest;
 import com.uber.cadence.ListWorkflowExecutionsResponse;
+import com.uber.cadence.PauseScheduleRequest;
+import com.uber.cadence.PauseScheduleResponse;
 import com.uber.cadence.PollForActivityTaskRequest;
 import com.uber.cadence.PollForActivityTaskResponse;
 import com.uber.cadence.PollForDecisionTaskRequest;
@@ -95,8 +113,12 @@ import com.uber.cadence.StartWorkflowExecutionAsyncResponse;
 import com.uber.cadence.StartWorkflowExecutionRequest;
 import com.uber.cadence.StartWorkflowExecutionResponse;
 import com.uber.cadence.TerminateWorkflowExecutionRequest;
+import com.uber.cadence.UnpauseScheduleRequest;
+import com.uber.cadence.UnpauseScheduleResponse;
 import com.uber.cadence.UpdateDomainRequest;
 import com.uber.cadence.UpdateDomainResponse;
+import com.uber.cadence.UpdateScheduleRequest;
+import com.uber.cadence.UpdateScheduleResponse;
 import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.WorkflowExecutionAlreadyCompletedError;
 import com.uber.cadence.WorkflowExecutionAlreadyStartedError;
@@ -110,6 +132,7 @@ import com.uber.cadence.internal.testservice.TestWorkflowStore.WorkflowState;
 import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -188,7 +211,8 @@ public final class TestWorkflowService implements IWorkflowService {
     try {
       TestWorkflowMutableState mutableState = executionsByWorkflowId.get(workflowId);
       if (mutableState == null && failNotExists) {
-        throw new EntityNotExistsError("Execution not found in mutable state: " + workflowId);
+        throw new EntityNotExistsError(
+            "Execution not found in mutable state: " + workflowId, Collections.emptyList());
       }
       return mutableState;
     } finally {
@@ -1245,6 +1269,154 @@ public final class TestWorkflowService implements IWorkflowService {
 
   public void unlockTimeSkipping(String caller) {
     store.getTimer().unlockTimeSkipping(caller);
+  }
+
+  @Override
+  public CreateScheduleResponse CreateSchedule(CreateScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, AccessDeniedError, TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public void CreateSchedule(CreateScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public DescribeScheduleResponse DescribeSchedule(DescribeScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, QueryFailedError,
+          LimitExceededError, AccessDeniedError, TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public void DescribeSchedule(DescribeScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public UpdateScheduleResponse UpdateSchedule(UpdateScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public void UpdateSchedule(UpdateScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public DeleteScheduleResponse DeleteSchedule(DeleteScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public void DeleteSchedule(DeleteScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public PauseScheduleResponse PauseSchedule(PauseScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public void PauseSchedule(PauseScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public UnpauseScheduleResponse UnpauseSchedule(UnpauseScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public void UnpauseSchedule(UnpauseScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public BackfillScheduleResponse BackfillSchedule(BackfillScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public void BackfillSchedule(BackfillScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public ListSchedulesResponse ListSchedules(ListSchedulesRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public void ListSchedules(ListSchedulesRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the test service");
+  }
+
+  @Override
+  public ListFailoverHistoryResponse ListFailoverHistory(ListFailoverHistoryRequest listRequest)
+      throws BadRequestError, ServiceBusyError, ClientVersionNotSupportedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void ListFailoverHistory(
+      ListFailoverHistoryRequest listRequest, AsyncMethodCallback resultHandler) throws TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void DeleteDomain(DeleteDomainRequest deleteRequest)
+      throws BadRequestError, ServiceBusyError, ClientVersionNotSupportedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void DeleteDomain(DeleteDomainRequest deleteRequest, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public FailoverDomainResponse FailoverDomain(FailoverDomainRequest failoverRequest)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          ClientVersionNotSupportedError, AccessDeniedError, TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void FailoverDomain(
+      FailoverDomainRequest failoverRequest, AsyncMethodCallback resultHandler) throws TException {
+    throw new UnsupportedOperationException("not implemented");
   }
 
   /**

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
@@ -39,6 +39,7 @@ import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.testservice.RequestContext.Timer;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -86,7 +87,8 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
         if (completed) {
           throw new EntityNotExistsError(
               "Attempt to add an event after a completion event: "
-                  + WorkflowExecutionUtils.prettyPrintHistoryEvent(event));
+                  + WorkflowExecutionUtils.prettyPrintHistoryEvent(event),
+              Collections.emptyList());
         }
         event.setEventId(history.size() + 1L);
         // It can be set in StateMachines.startActivityTask
@@ -377,7 +379,8 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
       throw new EntityNotExistsError(
           String.format(
               "Workflow execution result not found.  " + "WorkflowId: %s, RunId: %s",
-              execution.getWorkflowId(), execution.getRunId()));
+              execution.getWorkflowId(), execution.getRunId()),
+          Collections.emptyList());
     }
     return result;
   }

--- a/src/main/java/com/uber/cadence/serviceclient/IWorkflowServiceBase.java
+++ b/src/main/java/com/uber/cadence/serviceclient/IWorkflowServiceBase.java
@@ -719,4 +719,152 @@ public class IWorkflowServiceBase implements IWorkflowService {
   public CompletableFuture<Boolean> isHealthy() {
     throw new UnsupportedOperationException("unimplemented");
   }
+
+  @Override
+  public CreateScheduleResponse CreateSchedule(CreateScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, AccessDeniedError, TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void CreateSchedule(CreateScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public DescribeScheduleResponse DescribeSchedule(DescribeScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, QueryFailedError,
+          LimitExceededError, AccessDeniedError, TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void DescribeSchedule(DescribeScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public UpdateScheduleResponse UpdateSchedule(UpdateScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void UpdateSchedule(UpdateScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public DeleteScheduleResponse DeleteSchedule(DeleteScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void DeleteSchedule(DeleteScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public PauseScheduleResponse PauseSchedule(PauseScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void PauseSchedule(PauseScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public UnpauseScheduleResponse UnpauseSchedule(UnpauseScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void UnpauseSchedule(UnpauseScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public BackfillScheduleResponse BackfillSchedule(BackfillScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void BackfillSchedule(BackfillScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public ListSchedulesResponse ListSchedules(ListSchedulesRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void ListSchedules(ListSchedulesRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public ListFailoverHistoryResponse ListFailoverHistory(ListFailoverHistoryRequest listRequest)
+      throws BadRequestError, ServiceBusyError, ClientVersionNotSupportedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void ListFailoverHistory(
+      ListFailoverHistoryRequest listRequest, AsyncMethodCallback resultHandler) throws TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void DeleteDomain(DeleteDomainRequest deleteRequest)
+      throws BadRequestError, ServiceBusyError, ClientVersionNotSupportedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void DeleteDomain(DeleteDomainRequest deleteRequest, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public FailoverDomainResponse FailoverDomain(FailoverDomainRequest failoverRequest)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          ClientVersionNotSupportedError, AccessDeniedError, TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void FailoverDomain(
+      FailoverDomainRequest failoverRequest, AsyncMethodCallback resultHandler) throws TException {
+    throw new UnsupportedOperationException("unimplemented");
+  }
 }

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -2982,4 +2982,152 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       throws org.apache.thrift.TException {
     throw new UnsupportedOperationException("not implemented");
   }
+
+  @Override
+  public CreateScheduleResponse CreateSchedule(CreateScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, AccessDeniedError, TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public void CreateSchedule(CreateScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public DescribeScheduleResponse DescribeSchedule(DescribeScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, QueryFailedError,
+          LimitExceededError, AccessDeniedError, TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public void DescribeSchedule(DescribeScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public UpdateScheduleResponse UpdateSchedule(UpdateScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public void UpdateSchedule(UpdateScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public DeleteScheduleResponse DeleteSchedule(DeleteScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public void DeleteSchedule(DeleteScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public PauseScheduleResponse PauseSchedule(PauseScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public void PauseSchedule(PauseScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public UnpauseScheduleResponse UnpauseSchedule(UnpauseScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public void UnpauseSchedule(UnpauseScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public BackfillScheduleResponse BackfillSchedule(BackfillScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, WorkflowExecutionAlreadyCompletedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public void BackfillSchedule(BackfillScheduleRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public ListSchedulesResponse ListSchedules(ListSchedulesRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public void ListSchedules(ListSchedulesRequest request, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("Schedules are not supported by the TChannel client");
+  }
+
+  @Override
+  public ListFailoverHistoryResponse ListFailoverHistory(ListFailoverHistoryRequest listRequest)
+      throws BadRequestError, ServiceBusyError, ClientVersionNotSupportedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void ListFailoverHistory(
+      ListFailoverHistoryRequest listRequest, AsyncMethodCallback resultHandler) throws TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void DeleteDomain(DeleteDomainRequest deleteRequest)
+      throws BadRequestError, ServiceBusyError, ClientVersionNotSupportedError, AccessDeniedError,
+          TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void DeleteDomain(DeleteDomainRequest deleteRequest, AsyncMethodCallback resultHandler)
+      throws TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public FailoverDomainResponse FailoverDomain(FailoverDomainRequest failoverRequest)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          ClientVersionNotSupportedError, AccessDeniedError, TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void FailoverDomain(
+      FailoverDomainRequest failoverRequest, AsyncMethodCallback resultHandler) throws TException {
+    throw new UnsupportedOperationException("not implemented");
+  }
 }

--- a/src/test/java/com/uber/cadence/internal/common/FeatureFlagsHeaderTest.java
+++ b/src/test/java/com/uber/cadence/internal/common/FeatureFlagsHeaderTest.java
@@ -29,7 +29,7 @@ public class FeatureFlagsHeaderTest {
   @Test
   public void testSerializeEnabledFlag() {
     assertEquals(
-        "{\"WorkflowExecutionAlreadyCompletedErrorEnabled\":true}",
+        "{\"WorkflowExecutionAlreadyCompletedErrorEnabled\":true,\"AutoForwardingEnabled\":false}",
         FeatureFlagsHeader.serialize(
             new FeatureFlags().setWorkflowExecutionAlreadyCompletedErrorEnabled(true)));
   }
@@ -37,7 +37,7 @@ public class FeatureFlagsHeaderTest {
   @Test
   public void testSerializeUnsetFlags() {
     assertEquals(
-        "{\"WorkflowExecutionAlreadyCompletedErrorEnabled\":false}",
+        "{\"WorkflowExecutionAlreadyCompletedErrorEnabled\":false,\"AutoForwardingEnabled\":false}",
         FeatureFlagsHeader.serialize(new FeatureFlags()));
   }
 }

--- a/src/test/java/com/uber/cadence/internal/common/FeatureFlagsHeaderTest.java
+++ b/src/test/java/com/uber/cadence/internal/common/FeatureFlagsHeaderTest.java
@@ -24,20 +24,29 @@ import org.junit.Test;
 
 public class FeatureFlagsHeaderTest {
 
-  // The server rejects the whole header when it carries a field the IDL doesn't define, so these
-  // assertions are on the exact wire format rather than on the parsed flags.
+  // The server rejects the whole header when it carries a field name its proto unmarshaller
+  // doesn't know, so these assertions are on the exact wire format rather than on the parsed
+  // flags. The names come from the api.v1.FeatureFlags proto message: field 1 pins json_name to
+  // the Thrift spelling, field 2 uses the derived lowerCamel name.
   @Test
   public void testSerializeEnabledFlag() {
     assertEquals(
-        "{\"WorkflowExecutionAlreadyCompletedErrorEnabled\":true,\"AutoForwardingEnabled\":false}",
+        "{\"WorkflowExecutionAlreadyCompletedErrorEnabled\":true,\"autoforwardingEnabled\":false}",
         FeatureFlagsHeader.serialize(
             new FeatureFlags().setWorkflowExecutionAlreadyCompletedErrorEnabled(true)));
   }
 
   @Test
+  public void testSerializeAutoForwardingEnabled() {
+    assertEquals(
+        "{\"WorkflowExecutionAlreadyCompletedErrorEnabled\":false,\"autoforwardingEnabled\":true}",
+        FeatureFlagsHeader.serialize(new FeatureFlags().setAutoForwardingEnabled(true)));
+  }
+
+  @Test
   public void testSerializeUnsetFlags() {
     assertEquals(
-        "{\"WorkflowExecutionAlreadyCompletedErrorEnabled\":false,\"AutoForwardingEnabled\":false}",
+        "{\"WorkflowExecutionAlreadyCompletedErrorEnabled\":false,\"autoforwardingEnabled\":false}",
         FeatureFlagsHeader.serialize(new FeatureFlags()));
   }
 }

--- a/src/test/java/com/uber/cadence/internal/compatibility/ProtoObjects.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/ProtoObjects.java
@@ -31,7 +31,11 @@ public final class ProtoObjects {
   public static final ActivityType ACTIVITY_TYPE =
       ActivityType.newBuilder().setName("activityName").build();
   public static final TaskList TASK_LIST =
-      TaskList.newBuilder().setName("taskList").setKind(TaskListKind.TASK_LIST_KIND_NORMAL).build();
+      TaskList.newBuilder()
+          .setName("taskList")
+          .setKind(TaskListKind.TASK_LIST_KIND_NORMAL)
+          .setBaseName("baseName")
+          .build();
   public static final TaskListMetadata TASK_LIST_METADATA =
       TaskListMetadata.newBuilder()
           .setMaxTasksPerSecond(DoubleValue.newBuilder().setValue(10.0).build())

--- a/src/test/java/com/uber/cadence/internal/compatibility/ThriftObjects.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/ThriftObjects.java
@@ -31,7 +31,8 @@ public final class ThriftObjects {
   public static final TaskList TASK_LIST =
       new com.uber.cadence.TaskList()
           .setName("taskList")
-          .setKind(com.uber.cadence.TaskListKind.NORMAL);
+          .setKind(com.uber.cadence.TaskListKind.NORMAL)
+          .setBaseName("baseName");
   public static final TaskListMetadata TASK_LIST_METADATA =
       new TaskListMetadata().setMaxTasksPerSecond(10);
   public static final RetryPolicy RETRY_POLICY =

--- a/src/test/java/com/uber/cadence/internal/compatibility/proto/DecisionMapperTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/proto/DecisionMapperTest.java
@@ -125,10 +125,16 @@ public class DecisionMapperTest {
           break;
         case ContinueAsNewWorkflowExecution:
           assertMissingFields(
-              decision.continueAsNewWorkflowExecutionDecisionAttributes, "jitterStartSeconds");
+              decision.continueAsNewWorkflowExecutionDecisionAttributes,
+              "jitterStartSeconds",
+              "activeClusterSelectionPolicy", // aa: not wired yet
+              "cronOverlapPolicy"); // aa: not wired yet
           break;
         case StartChildWorkflowExecution:
-          assertNoMissingFields(decision.startChildWorkflowExecutionDecisionAttributes);
+          assertMissingFields(
+              decision.startChildWorkflowExecutionDecisionAttributes,
+              "activeClusterSelectionPolicy", // aa: not wired yet
+              "cronOverlapPolicy"); // aa: not wired yet
           break;
         case SignalExternalWorkflowExecution:
           assertNoMissingFields(decision.signalExternalWorkflowExecutionDecisionAttributes);

--- a/src/test/java/com/uber/cadence/internal/compatibility/proto/RequestMapperTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/proto/RequestMapperTest.java
@@ -129,11 +129,15 @@ public class RequestMapperTest<
         testCase(
             ThriftObjects.RESPOND_ACTIVITY_TASK_FAILED_BY_ID_REQUEST,
             ProtoObjects.RESPOND_ACTIVITY_TASK_FAILED_BY_ID_REQUEST,
-            RequestMapper::respondActivityTaskFailedByIdRequest),
+            RequestMapper::respondActivityTaskFailedByIdRequest,
+            "heartbeatDetails", // new IDL field, not wired yet
+            "failureOptions"), // new IDL field, not wired yet
         testCase(
             ThriftObjects.RESPOND_ACTIVITY_TASK_FAILED_REQUEST,
             ProtoObjects.RESPOND_ACTIVITY_TASK_FAILED_REQUEST,
-            RequestMapper::respondActivityTaskFailedRequest),
+            RequestMapper::respondActivityTaskFailedRequest,
+            "heartbeatDetails", // new IDL field, not wired yet
+            "failureOptions"), // new IDL field, not wired yet
         testCase(
             ThriftObjects.RESPOND_DECISION_TASK_COMPLETED_REQUEST,
             ProtoObjects.RESPOND_DECISION_TASK_COMPLETED_REQUEST,
@@ -161,11 +165,15 @@ public class RequestMapperTest<
         testCase(
             ThriftObjects.START_WORKFLOW_EXECUTION,
             ProtoObjects.START_WORKFLOW_EXECUTION,
-            RequestMapper::startWorkflowExecutionRequest),
+            RequestMapper::startWorkflowExecutionRequest,
+            "activeClusterSelectionPolicy", // aa: not wired yet
+            "cronOverlapPolicy"), // aa: not wired yet
         testCase(
             ThriftObjects.SIGNAL_WITH_START_WORKFLOW_EXECUTION,
             ProtoObjects.SIGNAL_WITH_START_WORKFLOW_EXECUTION,
-            RequestMapper::signalWithStartWorkflowExecutionRequest),
+            RequestMapper::signalWithStartWorkflowExecutionRequest,
+            "activeClusterSelectionPolicy", // aa: not wired yet
+            "cronOverlapPolicy"), // aa: not wired yet
         testCase(
             ThriftObjects.START_WORKFLOW_EXECUTION_ASYNC_REQUEST,
             ProtoObjects.START_WORKFLOW_EXECUTION_ASYNC_REQUEST,
@@ -233,7 +241,9 @@ public class RequestMapperTest<
             ThriftObjects.REGISTER_DOMAIN_REQUEST,
             ProtoObjects.REGISTER_DOMAIN_REQUEST,
             RequestMapper::registerDomainRequest,
-            "emitMetric"), // Thrift has this field but proto doens't have it
+            "emitMetric", // Thrift has this field but proto doens't have it
+            "activeClusters", // aa: not wired yet
+            "activeClustersByRegion"), // aa: not wired yet
         testCase(
             ThriftObjects.UPDATE_DOMAIN_REQUEST,
             ProtoObjects.UPDATE_DOMAIN_REQUEST,

--- a/src/test/java/com/uber/cadence/internal/compatibility/thrift/HistoryMapperEventTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/thrift/HistoryMapperEventTest.java
@@ -159,7 +159,9 @@ public class HistoryMapperEventTest<
           ThriftObjects.WORKFLOW_EXECUTION_STARTED_EVENT_ATTRIBUTES,
           "firstScheduledTimeNano",
           "partitionConfig",
-          "requestId"),
+          "requestId",
+          "activeClusterSelectionPolicy", // aa: not wired yet
+          "cronOverlapPolicy"), // aa: not wired yet
       testCase(
           EventType.WorkflowExecutionCompleted,
           ProtoObjects.WORKFLOW_EXECUTION_COMPLETED_EVENT_ATTRIBUTES,
@@ -201,7 +203,8 @@ public class HistoryMapperEventTest<
       testCase(
           EventType.ActivityTaskStarted,
           ProtoObjects.ACTIVITY_TASK_STARTED_EVENT_ATTRIBUTES,
-          ThriftObjects.ACTIVITY_TASK_STARTED_EVENT_ATTRIBUTES),
+          ThriftObjects.ACTIVITY_TASK_STARTED_EVENT_ATTRIBUTES,
+          "lastFailureOptions"), // new IDL field, not wired yet
       testCase(
           EventType.ActivityTaskCompleted,
           ProtoObjects.ACTIVITY_TASK_COMPLETED_EVENT_ATTRIBUTES,
@@ -209,11 +212,13 @@ public class HistoryMapperEventTest<
       testCase(
           EventType.ActivityTaskFailed,
           ProtoObjects.ACTIVITY_TASK_FAILED_EVENT_ATTRIBUTES,
-          ThriftObjects.ACTIVITY_TASK_FAILED_EVENT_ATTRIBUTES),
+          ThriftObjects.ACTIVITY_TASK_FAILED_EVENT_ATTRIBUTES,
+          "failureOptions"), // new IDL field, not wired yet
       testCase(
           EventType.ActivityTaskTimedOut,
           ProtoObjects.ACTIVITY_TASK_TIMED_OUT_EVENT_ATTRIBUTES,
-          ThriftObjects.ACTIVITY_TASK_TIMED_OUT_EVENT_ATTRIBUTES),
+          ThriftObjects.ACTIVITY_TASK_TIMED_OUT_EVENT_ATTRIBUTES,
+          "lastFailureOptions"), // new IDL field, not wired yet
       testCase(
           EventType.ActivityTaskCancelRequested,
           ProtoObjects.ACTIVITY_TASK_CANCEL_REQUESTED_EVENT_ATTRIBUTES,
@@ -279,11 +284,15 @@ public class HistoryMapperEventTest<
       testCase(
           EventType.WorkflowExecutionContinuedAsNew,
           ProtoObjects.WORKFLOW_EXECUTION_CONTINUED_AS_NEW_EVENT_ATTRIBUTES,
-          ThriftObjects.WORKFLOW_EXECUTION_CONTINUED_AS_NEW_EVENT_ATTRIBUTES),
+          ThriftObjects.WORKFLOW_EXECUTION_CONTINUED_AS_NEW_EVENT_ATTRIBUTES,
+          "activeClusterSelectionPolicy", // aa: not wired yet
+          "cronOverlapPolicy"), // aa: not wired yet
       testCase(
           EventType.StartChildWorkflowExecutionInitiated,
           ProtoObjects.START_CHILD_WORKFLOW_EXECUTION_INITIATED_EVENT_ATTRIBUTES,
-          ThriftObjects.START_CHILD_WORKFLOW_EXECUTION_INITIATED_EVENT_ATTRIBUTES),
+          ThriftObjects.START_CHILD_WORKFLOW_EXECUTION_INITIATED_EVENT_ATTRIBUTES,
+          "activeClusterSelectionPolicy", // aa: not wired yet
+          "cronOverlapPolicy"), // aa: not wired yet
       testCase(
           EventType.StartChildWorkflowExecutionFailed,
           ProtoObjects.START_CHILD_WORKFLOW_EXECUTION_FAILED_EVENT_ATTRIBUTES,

--- a/src/test/java/com/uber/cadence/internal/compatibility/thrift/ResponseMapperTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/thrift/ResponseMapperTest.java
@@ -91,7 +91,8 @@ public class ResponseMapperTest<
         testCase(
             ProtoObjects.DESCRIBE_TASK_LIST_RESPONSE,
             ThriftObjects.DESCRIBE_TASK_LIST_RESPONSE,
-            ResponseMapper::describeTaskListResponse),
+            ResponseMapper::describeTaskListResponse,
+            "taskList"), // new IDL field on response, not wired yet
         testCase(
             ProtoObjects.DESCRIBE_WORKFLOW_EXECUTION_RESPONSE,
             ThriftObjects.DESCRIBE_WORKFLOW_EXECUTION_RESPONSE,

--- a/src/test/java/com/uber/cadence/serviceclient/WorkflowServiceTChannelTest.java
+++ b/src/test/java/com/uber/cadence/serviceclient/WorkflowServiceTChannelTest.java
@@ -28,6 +28,7 @@ import com.uber.tchannel.messages.ThriftResponse;
 import com.uber.tchannel.messages.generated.HealthStatus;
 import com.uber.tchannel.messages.generated.Meta;
 import java.util.Arrays;
+import java.util.Collections;
 import org.apache.thrift.TException;
 import org.apache.thrift.async.AsyncMethodCallback;
 import org.junit.Before;
@@ -225,7 +226,7 @@ public class WorkflowServiceTChannelTest {
               ResponseCode.Error,
               new WorkflowService.DescribeDomain_result()
                   .setSuccess(new DescribeDomainResponse())
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -279,7 +280,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.ListDomains_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null,
             },
@@ -344,7 +345,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.ResetWorkflowExecution_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -415,7 +416,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.TerminateWorkflowExecution_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -507,7 +508,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.ListOpenWorkflowExecutions_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -581,7 +582,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.ListClosedWorkflowExecutions_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -648,7 +649,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.ListWorkflowExecutions_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -714,7 +715,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.ListArchivedWorkflowExecutions_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -782,7 +783,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.ScanWorkflowExecutions_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -847,7 +848,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.CountWorkflowExecutions_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -1007,7 +1008,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.ResetStickyTaskList_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -1107,7 +1108,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.QueryWorkflow_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -1164,7 +1165,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.DescribeWorkflowExecution_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -1346,7 +1347,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.ListTaskListPartitions_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -1401,7 +1402,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.UpdateDomain_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -1467,7 +1468,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.GetWorkflowExecutionHistory_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -1581,7 +1582,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.StartWorkflowExecutionAsync_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -1702,7 +1703,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.StartWorkflowExecution_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -1784,7 +1785,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.GetTaskListsByDomain_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -1862,7 +1863,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.DeprecateDomain_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -1964,7 +1965,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.PollForDecisionTask_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -2022,7 +2023,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.RespondDecisionTaskCompleted_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -2110,7 +2111,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.PollForActivityTask_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -2188,7 +2189,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.RecordActivityTaskHeartbeat_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -2278,7 +2279,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.RecordActivityTaskHeartbeatByID_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -2364,7 +2365,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.RespondActivityTaskCompleted_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -2454,7 +2455,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.RespondActivityTaskCompletedByID_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -2539,7 +2540,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.RespondActivityTaskFailed_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -2628,7 +2629,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.RespondActivityTaskFailedByID_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -2713,7 +2714,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.RespondActivityTaskCanceled_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -2809,7 +2810,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.RespondActivityTaskCanceledByID_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -2899,7 +2900,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.RequestCancelWorkflowExecution_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -2984,7 +2985,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.SignalWorkflowExecution_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -3082,7 +3083,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.SignalWithStartWorkflowExecution_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -3158,7 +3159,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.RefreshWorkflowTasks_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -3227,7 +3228,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.SignalWithStartWorkflowExecutionAsync_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },
@@ -3299,7 +3300,7 @@ public class WorkflowServiceTChannelTest {
             {
               ResponseCode.Error,
               new WorkflowService.RespondDecisionTaskFailed_result()
-                  .setEntityNotExistError(new EntityNotExistsError("")),
+                  .setEntityNotExistError(new EntityNotExistsError("", Collections.emptyList())),
               EntityNotExistsError.class,
               null
             },


### PR DESCRIPTION
**Stack (1 of 3)** backporting active-active support to v3.13.x — merge in order; when this merges, GitHub retargets part 2 onto `v3.13.x`:
1. 👉 this PR — IDL bump + adaptation
2. `aa-backport-v3.13.x-mappers` — aa proto/thrift mappers (#1050 parity)
3. `aa-backport-v3.13.x-wiring` — ActiveClusterSelectionPolicy wiring (backport of #1089)

## What

Bumps the `src/main/idls` submodule to `d6d4d81` (master's pin, #1083), bringing in the active-active types (`ActiveClusterSelectionPolicy`, `ClusterAttribute`, `ActiveClusters`, `CronOverlapPolicy`) needed by the follow-up PRs. v3 generates thrift and proto Java from the submodule at build time, so no generated code is checked in.

The bump grew the IDL surface, so this also adapts v3:
- **11 new service RPC stubs** (8 schedule RPCs plus `ListFailoverHistory`/`DeleteDomain`/`FailoverDomain`) throwing `UnsupportedOperationException` in `IWorkflowServiceBase`, `WorkflowServiceTChannel`, `Thrift2ProtoAdapter`, `TestWorkflowService`; delegated in the test-environment wrappers. These features are not supported by the v3 client.
- `EntityNotExistsError` gained a required `activeClusters` field, changing the generated constructor — all call sites pass an empty list.
- New `TaskListKind.EPHEMERAL` and `TaskList.baseName` mapped in both mapper directions (the non-aa tasklist hunks of #1050).
- `FeatureFlags` gained `AutoForwardingEnabled` — header test expectations updated.
- New not-yet-wired IDL fields declared expected-missing in mapper coverage tests (each labeled); parts 2–3 un-declare the aa fields as they wire them.

## Testing

Full `./gradlew test` green (2292 tests) and `verGJF` clean. `ReplayDeciderCacheTests.whenHistoryIsPartialCachedEntryIsReturned` is a pre-existing timing flake unrelated to this change (passes 3/3 in isolation).