### PR TITLE
feat: port active-active proto/thrift mappers from master (#1050 parity)

### DIFF
--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/DecisionMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/DecisionMapper.java
@@ -16,11 +16,13 @@
 package com.uber.cadence.internal.compatibility.proto;
 
 import static com.uber.cadence.internal.compatibility.proto.EnumMapper.continueAsNewInitiator;
+import static com.uber.cadence.internal.compatibility.proto.EnumMapper.cronOverlapPolicy;
 import static com.uber.cadence.internal.compatibility.proto.EnumMapper.parentClosePolicy;
 import static com.uber.cadence.internal.compatibility.proto.EnumMapper.workflowIdReusePolicy;
 import static com.uber.cadence.internal.compatibility.proto.Helpers.arrayToByteString;
 import static com.uber.cadence.internal.compatibility.proto.Helpers.longToInt;
 import static com.uber.cadence.internal.compatibility.proto.Helpers.secondsToDuration;
+import static com.uber.cadence.internal.compatibility.proto.TypeMapper.activeClusterSelectionPolicy;
 import static com.uber.cadence.internal.compatibility.proto.TypeMapper.activityType;
 import static com.uber.cadence.internal.compatibility.proto.TypeMapper.failure;
 import static com.uber.cadence.internal.compatibility.proto.TypeMapper.header;
@@ -210,6 +212,13 @@ class DecisionMapper {
           if (attr.getCronSchedule() != null) {
             builder.setCronSchedule(attr.getCronSchedule());
           }
+          if (attr.getCronOverlapPolicy() != null) {
+            builder.setCronOverlapPolicy(cronOverlapPolicy(attr.getCronOverlapPolicy()));
+          }
+          if (attr.getActiveClusterSelectionPolicy() != null) {
+            builder.setActiveClusterSelectionPolicy(
+                activeClusterSelectionPolicy(attr.getActiveClusterSelectionPolicy()));
+          }
           decision.setContinueAsNewWorkflowExecutionDecisionAttributes(builder);
         }
         break;
@@ -245,6 +254,13 @@ class DecisionMapper {
           }
           if (attr.getCronSchedule() != null) {
             builder.setCronSchedule(attr.getCronSchedule());
+          }
+          if (attr.getCronOverlapPolicy() != null) {
+            builder.setCronOverlapPolicy(cronOverlapPolicy(attr.getCronOverlapPolicy()));
+          }
+          if (attr.getActiveClusterSelectionPolicy() != null) {
+            builder.setActiveClusterSelectionPolicy(
+                activeClusterSelectionPolicy(attr.getActiveClusterSelectionPolicy()));
           }
           decision.setStartChildWorkflowExecutionDecisionAttributes(builder);
         }

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/EnumMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/EnumMapper.java
@@ -45,6 +45,7 @@ import static com.uber.cadence.api.v1.QueryResultType.QUERY_RESULT_TYPE_INVALID;
 
 import com.uber.cadence.api.v1.ArchivalStatus;
 import com.uber.cadence.api.v1.ContinueAsNewInitiator;
+import com.uber.cadence.api.v1.CronOverlapPolicy;
 import com.uber.cadence.api.v1.DecisionTaskFailedCause;
 import com.uber.cadence.api.v1.EventFilterType;
 import com.uber.cadence.api.v1.ParentClosePolicy;
@@ -290,6 +291,19 @@ public final class EnumMapper {
         return QUERY_RESULT_TYPE_ANSWERED;
       case FAILED:
         return QUERY_RESULT_TYPE_FAILED;
+    }
+    throw new IllegalArgumentException("unexpected enum value");
+  }
+
+  public static CronOverlapPolicy cronOverlapPolicy(com.uber.cadence.CronOverlapPolicy t) {
+    if (t == null) {
+      return CronOverlapPolicy.CRON_OVERLAP_POLICY_INVALID;
+    }
+    switch (t) {
+      case SKIPPED:
+        return CronOverlapPolicy.CRON_OVERLAP_POLICY_SKIPPED;
+      case BUFFERONE:
+        return CronOverlapPolicy.CRON_OVERLAP_POLICY_BUFFER_ONE;
     }
     throw new IllegalArgumentException("unexpected enum value");
   }

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/RequestMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/RequestMapper.java
@@ -17,6 +17,7 @@ package com.uber.cadence.internal.compatibility.proto;
 
 import static com.uber.cadence.internal.compatibility.proto.DecisionMapper.decisionArray;
 import static com.uber.cadence.internal.compatibility.proto.EnumMapper.archivalStatus;
+import static com.uber.cadence.internal.compatibility.proto.EnumMapper.cronOverlapPolicy;
 import static com.uber.cadence.internal.compatibility.proto.EnumMapper.decisionTaskFailedCause;
 import static com.uber.cadence.internal.compatibility.proto.EnumMapper.eventFilterType;
 import static com.uber.cadence.internal.compatibility.proto.EnumMapper.queryConsistencyLevel;
@@ -30,6 +31,8 @@ import static com.uber.cadence.internal.compatibility.proto.Helpers.newFieldMask
 import static com.uber.cadence.internal.compatibility.proto.Helpers.nullToEmpty;
 import static com.uber.cadence.internal.compatibility.proto.Helpers.secondsToDuration;
 import static com.uber.cadence.internal.compatibility.proto.Helpers.unixNanoToTime;
+import static com.uber.cadence.internal.compatibility.proto.TypeMapper.activeClusterSelectionPolicy;
+import static com.uber.cadence.internal.compatibility.proto.TypeMapper.activeClusters;
 import static com.uber.cadence.internal.compatibility.proto.TypeMapper.badBinaries;
 import static com.uber.cadence.internal.compatibility.proto.TypeMapper.clusterReplicationConfigurationArray;
 import static com.uber.cadence.internal.compatibility.proto.TypeMapper.failure;
@@ -113,6 +116,7 @@ public class RequestMapper {
   private static final String DomainUpdateVisibilityArchivalURIField = "visibility_archival_uri";
   private static final String DomainUpdateActiveClusterNameField = "active_cluster_name";
   private static final String DomainUpdateClustersField = "clusters";
+  private static final String DomainUpdateActiveClustersField = "active_clusters";
   private static final String DomainUpdateDeleteBadBinaryField = "delete_bad_binary";
   private static final String DomainUpdateFailoverTimeoutField = "failover_timeout";
 
@@ -533,6 +537,13 @@ public class RequestMapper {
     if (t.getCronSchedule() != null) {
       builder.setCronSchedule(t.getCronSchedule());
     }
+    if (t.getCronOverlapPolicy() != null) {
+      builder.setCronOverlapPolicy(cronOverlapPolicy(t.getCronOverlapPolicy()));
+    }
+    if (t.getActiveClusterSelectionPolicy() != null) {
+      builder.setActiveClusterSelectionPolicy(
+          activeClusterSelectionPolicy(t.getActiveClusterSelectionPolicy()));
+    }
     if (t.getDelayStartSeconds() > 0) {
       builder.setDelayStart(secondsToDuration(t.getDelayStartSeconds()));
     }
@@ -630,6 +641,13 @@ public class RequestMapper {
     }
     if (t.getCronSchedule() != null) {
       builder.setCronSchedule(t.getCronSchedule());
+    }
+    if (t.getCronOverlapPolicy() != null) {
+      builder.setCronOverlapPolicy(cronOverlapPolicy(t.getCronOverlapPolicy()));
+    }
+    if (t.getActiveClusterSelectionPolicy() != null) {
+      builder.setActiveClusterSelectionPolicy(
+          activeClusterSelectionPolicy(t.getActiveClusterSelectionPolicy()));
     }
     if (t.getIdentity() != null) {
       builder.setIdentity(t.getIdentity());
@@ -861,6 +879,9 @@ public class RequestMapper {
     if (t.getName() != null) {
       builder.setName(t.getName());
     }
+    if (t.getActiveClusters() != null) {
+      builder.setActiveClusters(activeClusters(t.getActiveClusters()));
+    }
     return builder.build();
   }
 
@@ -933,6 +954,10 @@ public class RequestMapper {
         builder.addAllClusters(
             clusterReplicationConfigurationArray(replicationConfiguration.getClusters()));
         fields.add(DomainUpdateClustersField);
+      }
+      if (replicationConfiguration.getActiveClusters() != null) {
+        builder.setActiveClusters(activeClusters(replicationConfiguration.getActiveClusters()));
+        fields.add(DomainUpdateActiveClustersField);
       }
     }
     if (t.getDeleteBadBinary() != null) {

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/TypeMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/TypeMapper.java
@@ -24,9 +24,14 @@ import static com.uber.cadence.internal.compatibility.proto.Helpers.secondsToDur
 import static com.uber.cadence.internal.compatibility.proto.Helpers.unixNanoToTime;
 
 import com.google.common.base.Strings;
+import com.uber.cadence.api.v1.ActiveClusterInfo;
+import com.uber.cadence.api.v1.ActiveClusterSelectionPolicy;
+import com.uber.cadence.api.v1.ActiveClusters;
 import com.uber.cadence.api.v1.ActivityType;
 import com.uber.cadence.api.v1.BadBinaries;
 import com.uber.cadence.api.v1.BadBinaryInfo;
+import com.uber.cadence.api.v1.ClusterAttribute;
+import com.uber.cadence.api.v1.ClusterAttributeScope;
 import com.uber.cadence.api.v1.ClusterReplicationConfiguration;
 import com.uber.cadence.api.v1.Failure;
 import com.uber.cadence.api.v1.Header;
@@ -367,5 +372,67 @@ class TypeMapper {
       v.put(key, workflowQueryResult(t.get(key)));
     }
     return v;
+  }
+
+  static ActiveClusters activeClusters(com.uber.cadence.ActiveClusters t) {
+    if (t == null) {
+      return ActiveClusters.newBuilder().build();
+    }
+    Map<String, ClusterAttributeScope> clusterAttributeScopes = new HashMap<>();
+    if (t.getActiveClustersByClusterAttribute() != null) {
+      for (Map.Entry<String, com.uber.cadence.ClusterAttributeScope> entry :
+          t.getActiveClustersByClusterAttribute().entrySet()) {
+        clusterAttributeScopes.put(entry.getKey(), clusterAttributeScope(entry.getValue()));
+      }
+    }
+    return ActiveClusters.newBuilder()
+        .putAllActiveClustersByClusterAttribute(clusterAttributeScopes)
+        .build();
+  }
+
+  static ClusterAttributeScope clusterAttributeScope(com.uber.cadence.ClusterAttributeScope t) {
+    if (t == null) {
+      return ClusterAttributeScope.newBuilder().build();
+    }
+    Map<String, ActiveClusterInfo> clusterAttributes = new HashMap<>();
+    if (t.getClusterAttributes() != null) {
+      for (Map.Entry<String, com.uber.cadence.ActiveClusterInfo> entry :
+          t.getClusterAttributes().entrySet()) {
+        clusterAttributes.put(entry.getKey(), activeClusterInfo(entry.getValue()));
+      }
+    }
+    return ClusterAttributeScope.newBuilder().putAllClusterAttributes(clusterAttributes).build();
+  }
+
+  static ActiveClusterInfo activeClusterInfo(com.uber.cadence.ActiveClusterInfo t) {
+    if (t == null) {
+      return ActiveClusterInfo.newBuilder().build();
+    }
+    return ActiveClusterInfo.newBuilder()
+        .setActiveClusterName(Helpers.nullToEmpty(t.getActiveClusterName()))
+        .setFailoverVersion(t.getFailoverVersion())
+        .build();
+  }
+
+  static ActiveClusterSelectionPolicy activeClusterSelectionPolicy(
+      com.uber.cadence.ActiveClusterSelectionPolicy t) {
+    if (t == null) {
+      return ActiveClusterSelectionPolicy.newBuilder().build();
+    }
+    ActiveClusterSelectionPolicy.Builder builder = ActiveClusterSelectionPolicy.newBuilder();
+    if (t.getClusterAttribute() != null) {
+      builder.setClusterAttribute(clusterAttribute(t.getClusterAttribute()));
+    }
+    return builder.build();
+  }
+
+  static ClusterAttribute clusterAttribute(com.uber.cadence.ClusterAttribute t) {
+    if (t == null) {
+      return ClusterAttribute.newBuilder().build();
+    }
+    return ClusterAttribute.newBuilder()
+        .setScope(Helpers.nullToEmpty(t.getScope()))
+        .setName(Helpers.nullToEmpty(t.getName()))
+        .build();
   }
 }

--- a/src/main/java/com/uber/cadence/internal/compatibility/thrift/EnumMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/thrift/EnumMapper.java
@@ -21,6 +21,7 @@ import com.uber.cadence.ArchivalStatus;
 import com.uber.cadence.CancelExternalWorkflowExecutionFailedCause;
 import com.uber.cadence.ChildWorkflowExecutionFailedCause;
 import com.uber.cadence.ContinueAsNewInitiator;
+import com.uber.cadence.CronOverlapPolicy;
 import com.uber.cadence.DecisionTaskFailedCause;
 import com.uber.cadence.DecisionTaskTimedOutCause;
 import com.uber.cadence.DomainStatus;
@@ -342,6 +343,18 @@ public final class EnumMapper {
         return null;
       case CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_WORKFLOW_ALREADY_RUNNING:
         return ChildWorkflowExecutionFailedCause.WORKFLOW_ALREADY_RUNNING;
+    }
+    throw new IllegalArgumentException("unexpected enum value");
+  }
+
+  public static CronOverlapPolicy cronOverlapPolicy(com.uber.cadence.api.v1.CronOverlapPolicy t) {
+    switch (t) {
+      case CRON_OVERLAP_POLICY_INVALID:
+        return null;
+      case CRON_OVERLAP_POLICY_SKIPPED:
+        return CronOverlapPolicy.SKIPPED;
+      case CRON_OVERLAP_POLICY_BUFFER_ONE:
+        return CronOverlapPolicy.BUFFERONE;
     }
     throw new IllegalArgumentException("unexpected enum value");
   }

--- a/src/main/java/com/uber/cadence/internal/compatibility/thrift/ResponseMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/thrift/ResponseMapper.java
@@ -23,6 +23,7 @@ import static com.uber.cadence.internal.compatibility.thrift.Helpers.durationToS
 import static com.uber.cadence.internal.compatibility.thrift.Helpers.timeToUnixNano;
 import static com.uber.cadence.internal.compatibility.thrift.Helpers.toInt64Value;
 import static com.uber.cadence.internal.compatibility.thrift.HistoryMapper.history;
+import static com.uber.cadence.internal.compatibility.thrift.TypeMapper.activeClusters;
 import static com.uber.cadence.internal.compatibility.thrift.TypeMapper.activityLocalDispatchInfoMap;
 import static com.uber.cadence.internal.compatibility.thrift.TypeMapper.activityType;
 import static com.uber.cadence.internal.compatibility.thrift.TypeMapper.autoConfigHint;
@@ -381,6 +382,7 @@ public class ResponseMapper {
     replicationConfiguration.setActiveClusterName(t.getDomain().getActiveClusterName());
     replicationConfiguration.setClusters(
         clusterReplicationConfigurationArray(t.getDomain().getClustersList()));
+    replicationConfiguration.setActiveClusters(activeClusters(t.getDomain().getActiveClusters()));
 
     response.setFailoverVersion(t.getDomain().getFailoverVersion());
     response.setIsGlobalDomain(t.getDomain().getIsGlobalDomain());
@@ -452,6 +454,8 @@ public class ResponseMapper {
     domainReplicationConfiguration.setActiveClusterName(t.getDomain().getActiveClusterName());
     domainReplicationConfiguration.setClusters(
         clusterReplicationConfigurationArray(t.getDomain().getClustersList()));
+    domainReplicationConfiguration.setActiveClusters(
+        activeClusters(t.getDomain().getActiveClusters()));
     updateDomainResponse.setFailoverVersion(t.getDomain().getFailoverVersion());
     updateDomainResponse.setIsGlobalDomain(t.getDomain().getIsGlobalDomain());
     return updateDomainResponse;

--- a/src/main/java/com/uber/cadence/internal/compatibility/thrift/TypeMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/thrift/TypeMapper.java
@@ -29,11 +29,16 @@ import static com.uber.cadence.internal.compatibility.thrift.Helpers.durationToD
 import static com.uber.cadence.internal.compatibility.thrift.Helpers.durationToSeconds;
 import static com.uber.cadence.internal.compatibility.thrift.Helpers.timeToUnixNano;
 
+import com.uber.cadence.ActiveClusterInfo;
+import com.uber.cadence.ActiveClusterSelectionPolicy;
+import com.uber.cadence.ActiveClusters;
 import com.uber.cadence.ActivityLocalDispatchInfo;
 import com.uber.cadence.ActivityType;
 import com.uber.cadence.AutoConfigHint;
 import com.uber.cadence.BadBinaries;
 import com.uber.cadence.BadBinaryInfo;
+import com.uber.cadence.ClusterAttribute;
+import com.uber.cadence.ClusterAttributeScope;
 import com.uber.cadence.ClusterReplicationConfiguration;
 import com.uber.cadence.DataBlob;
 import com.uber.cadence.DescribeDomainResponse;
@@ -525,6 +530,7 @@ class TypeMapper {
     domainReplicationConfiguration.setActiveClusterName(t.getActiveClusterName());
     domainReplicationConfiguration.setClusters(
         clusterReplicationConfigurationArray(t.getClustersList()));
+    domainReplicationConfiguration.setActiveClusters(activeClusters(t.getActiveClusters()));
     res.setFailoverVersion(t.getFailoverVersion());
     res.setIsGlobalDomain(t.getIsGlobalDomain());
 
@@ -697,5 +703,71 @@ class TypeMapper {
     autoConfigHint.setEnableAutoConfig(t.getEnableAutoConfig());
     autoConfigHint.setPollerWaitTimeInMs(t.getPollerWaitTimeInMs());
     return autoConfigHint;
+  }
+
+  static ActiveClusters activeClusters(com.uber.cadence.api.v1.ActiveClusters t) {
+    if (t == null || t == com.uber.cadence.api.v1.ActiveClusters.getDefaultInstance()) {
+      return null;
+    }
+    ActiveClusters activeClusters = new ActiveClusters();
+    Map<String, ClusterAttributeScope> clusterAttributeScopes = new HashMap<>();
+    if (t.getActiveClustersByClusterAttributeMap() != null) {
+      for (Map.Entry<String, com.uber.cadence.api.v1.ClusterAttributeScope> entry :
+          t.getActiveClustersByClusterAttributeMap().entrySet()) {
+        clusterAttributeScopes.put(entry.getKey(), clusterAttributeScope(entry.getValue()));
+      }
+    }
+    activeClusters.setActiveClustersByClusterAttribute(clusterAttributeScopes);
+    return activeClusters;
+  }
+
+  static ClusterAttributeScope clusterAttributeScope(
+      com.uber.cadence.api.v1.ClusterAttributeScope t) {
+    if (t == null || t == com.uber.cadence.api.v1.ClusterAttributeScope.getDefaultInstance()) {
+      return null;
+    }
+    ClusterAttributeScope scope = new ClusterAttributeScope();
+    Map<String, ActiveClusterInfo> clusterAttributes = new HashMap<>();
+    if (t.getClusterAttributesMap() != null) {
+      for (Map.Entry<String, com.uber.cadence.api.v1.ActiveClusterInfo> entry :
+          t.getClusterAttributesMap().entrySet()) {
+        clusterAttributes.put(entry.getKey(), activeClusterInfo(entry.getValue()));
+      }
+    }
+    scope.setClusterAttributes(clusterAttributes);
+    return scope;
+  }
+
+  static ActiveClusterInfo activeClusterInfo(com.uber.cadence.api.v1.ActiveClusterInfo t) {
+    if (t == null || t == com.uber.cadence.api.v1.ActiveClusterInfo.getDefaultInstance()) {
+      return null;
+    }
+    ActiveClusterInfo info = new ActiveClusterInfo();
+    info.setActiveClusterName(t.getActiveClusterName());
+    info.setFailoverVersion(t.getFailoverVersion());
+    return info;
+  }
+
+  static ActiveClusterSelectionPolicy activeClusterSelectionPolicy(
+      com.uber.cadence.api.v1.ActiveClusterSelectionPolicy t) {
+    if (t == null
+        || t == com.uber.cadence.api.v1.ActiveClusterSelectionPolicy.getDefaultInstance()) {
+      return null;
+    }
+    ActiveClusterSelectionPolicy policy = new ActiveClusterSelectionPolicy();
+    if (t.hasClusterAttribute()) {
+      policy.setClusterAttribute(clusterAttribute(t.getClusterAttribute()));
+    }
+    return policy;
+  }
+
+  static ClusterAttribute clusterAttribute(com.uber.cadence.api.v1.ClusterAttribute t) {
+    if (t == null || t == com.uber.cadence.api.v1.ClusterAttribute.getDefaultInstance()) {
+      return null;
+    }
+    ClusterAttribute attr = new ClusterAttribute();
+    attr.setScope(t.getScope());
+    attr.setName(t.getName());
+    return attr;
   }
 }

--- a/src/test/java/com/uber/cadence/internal/compatibility/ProtoObjects.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/ProtoObjects.java
@@ -102,6 +102,25 @@ public final class ProtoObjects {
       ResetPoints.newBuilder().addPoints(RESET_POINT_INFO).build();
   public static final ClusterReplicationConfiguration CLUSTER_REPLICATION_CONFIGURATION =
       ClusterReplicationConfiguration.newBuilder().setClusterName("cluster").build();
+  public static final ActiveClusterInfo ACTIVE_CLUSTER_INFO =
+      ActiveClusterInfo.newBuilder()
+          .setActiveClusterName("activeCluster")
+          .setFailoverVersion(1)
+          .build();
+  public static final ClusterAttributeScope CLUSTER_ATTRIBUTE_SCOPE =
+      ClusterAttributeScope.newBuilder()
+          .putClusterAttributes("region", ACTIVE_CLUSTER_INFO)
+          .build();
+  public static final ActiveClusters ACTIVE_CLUSTERS =
+      ActiveClusters.newBuilder()
+          .putActiveClustersByClusterAttribute("region", CLUSTER_ATTRIBUTE_SCOPE)
+          .build();
+  public static final ClusterAttribute CLUSTER_ATTRIBUTE =
+      ClusterAttribute.newBuilder().setScope("scope").setName("region").build();
+  public static final ActiveClusterSelectionPolicy ACTIVE_CLUSTER_SELECTION_POLICY =
+      ActiveClusterSelectionPolicy.newBuilder().setClusterAttribute(CLUSTER_ATTRIBUTE).build();
+  public static final CronOverlapPolicy CRON_OVERLAP_POLICY =
+      CronOverlapPolicy.CRON_OVERLAP_POLICY_SKIPPED;
   public static final PollerInfo POLLER_INFO =
       PollerInfo.newBuilder()
           .setIdentity("identity")
@@ -237,6 +256,7 @@ public final class ProtoObjects {
           .setVisibilityArchivalUri("visibilityArchivalUri")
           .setActiveClusterName("activeCluster")
           .addClusters(CLUSTER_REPLICATION_CONFIGURATION)
+          .setActiveClusters(ACTIVE_CLUSTERS)
           .setFailoverVersion(1)
           .setIsGlobalDomain(true)
           .build();
@@ -334,7 +354,9 @@ public final class ProtoObjects {
                   .setMemo(MEMO)
                   .setSearchAttributes(SEARCH_ATTRIBUTES)
                   .setRetryPolicy(RETRY_POLICY)
-                  .setCronSchedule("cron"))
+                  .setCronSchedule("cron")
+                  .setCronOverlapPolicy(CRON_OVERLAP_POLICY)
+                  .setActiveClusterSelectionPolicy(ACTIVE_CLUSTER_SELECTION_POLICY))
           .build();
   public static Decision DECISION_START_CHILD_WORKFLOW_EXECUTION =
       Decision.newBuilder()
@@ -355,7 +377,9 @@ public final class ProtoObjects {
                   .setControl(utf8("control"))
                   .setParentClosePolicy(ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON)
                   .setWorkflowIdReusePolicy(
-                      WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE))
+                      WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE)
+                  .setCronOverlapPolicy(CRON_OVERLAP_POLICY)
+                  .setActiveClusterSelectionPolicy(ACTIVE_CLUSTER_SELECTION_POLICY))
           .build();
   public static Decision DECISION_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION =
       Decision.newBuilder()
@@ -1027,6 +1051,8 @@ public final class ProtoObjects {
           .setDelayStart(seconds(3))
           .setJitterStart(seconds(0))
           .setFirstRunAt(timestampNanos(123456789))
+          .setCronOverlapPolicy(CRON_OVERLAP_POLICY)
+          .setActiveClusterSelectionPolicy(ACTIVE_CLUSTER_SELECTION_POLICY)
           .build();
 
   public static final SignalWithStartWorkflowExecutionRequest SIGNAL_WITH_START_WORKFLOW_EXECUTION =
@@ -1161,6 +1187,7 @@ public final class ProtoObjects {
           .setHistoryArchivalUri("historyArchivalUri")
           .setVisibilityArchivalStatus(ArchivalStatus.ARCHIVAL_STATUS_DISABLED)
           .setVisibilityArchivalUri("visibilityArchivalUri")
+          .setActiveClusters(ACTIVE_CLUSTERS)
           .build();
 
   public static final UpdateDomainRequest UPDATE_DOMAIN_REQUEST =
@@ -1185,6 +1212,7 @@ public final class ProtoObjects {
           .setVisibilityArchivalUri("visibilityArchivalUri")
           .addAllClusters(ImmutableList.of(CLUSTER_REPLICATION_CONFIGURATION))
           .setActiveClusterName("activeCluster")
+          .setActiveClusters(ACTIVE_CLUSTERS)
           .setDeleteBadBinary("deleteBadBinary")
           .setFailoverTimeout(seconds(1))
           .setUpdateMask(
@@ -1200,6 +1228,7 @@ public final class ProtoObjects {
                   .addPaths("visibility_archival_uri")
                   .addPaths("active_cluster_name")
                   .addPaths("clusters")
+                  .addPaths("active_clusters")
                   .addPaths("delete_bad_binary")
                   .addPaths("failover_timeout")
                   .build())

--- a/src/test/java/com/uber/cadence/internal/compatibility/ThriftObjects.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/ThriftObjects.java
@@ -85,6 +85,19 @@ public final class ThriftObjects {
       new ResetPoints().setPoints(Collections.singletonList(RESET_POINT_INFO));
   public static final ClusterReplicationConfiguration CLUSTER_REPLICATION_CONFIGURATION =
       new ClusterReplicationConfiguration().setClusterName("cluster");
+  public static final ActiveClusterInfo ACTIVE_CLUSTER_INFO =
+      new ActiveClusterInfo().setActiveClusterName("activeCluster").setFailoverVersion(1);
+  public static final ClusterAttributeScope CLUSTER_ATTRIBUTE_SCOPE =
+      new ClusterAttributeScope()
+          .setClusterAttributes(ImmutableMap.of("region", ACTIVE_CLUSTER_INFO));
+  public static final ActiveClusters ACTIVE_CLUSTERS =
+      new ActiveClusters()
+          .setActiveClustersByClusterAttribute(ImmutableMap.of("region", CLUSTER_ATTRIBUTE_SCOPE));
+  public static final ClusterAttribute CLUSTER_ATTRIBUTE =
+      new ClusterAttribute().setScope("scope").setName("region");
+  public static final ActiveClusterSelectionPolicy ACTIVE_CLUSTER_SELECTION_POLICY =
+      new ActiveClusterSelectionPolicy().setClusterAttribute(CLUSTER_ATTRIBUTE);
+  public static final CronOverlapPolicy CRON_OVERLAP_POLICY = CronOverlapPolicy.SKIPPED;
   public static final PollerInfo POLLER_INFO =
       new PollerInfo().setIdentity("identity").setLastAccessTime(1).setRatePerSecond(2.0);
   public static final TaskIDBlock TASK_ID_BLOCK = new TaskIDBlock().setStartID(1).setEndID(2);
@@ -194,7 +207,8 @@ public final class ThriftObjects {
   public static final DomainReplicationConfiguration DOMAIN_REPLICATION_CONFIGURATION =
       new DomainReplicationConfiguration()
           .setActiveClusterName("activeCluster")
-          .setClusters(ImmutableList.of(CLUSTER_REPLICATION_CONFIGURATION));
+          .setClusters(ImmutableList.of(CLUSTER_REPLICATION_CONFIGURATION))
+          .setActiveClusters(ACTIVE_CLUSTERS);
 
   public static Decision DECISION_SCHEDULE_ACTIVITY_TASK =
       new Decision()
@@ -276,7 +290,9 @@ public final class ThriftObjects {
                   .setMemo(MEMO)
                   .setSearchAttributes(SEARCH_ATTRIBUTES)
                   .setRetryPolicy(RETRY_POLICY)
-                  .setCronSchedule("cron"));
+                  .setCronSchedule("cron")
+                  .setCronOverlapPolicy(CRON_OVERLAP_POLICY)
+                  .setActiveClusterSelectionPolicy(ACTIVE_CLUSTER_SELECTION_POLICY));
   public static Decision DECISION_START_CHILD_WORKFLOW_EXECUTION =
       new Decision()
           .setDecisionType(DecisionType.StartChildWorkflowExecution)
@@ -296,7 +312,9 @@ public final class ThriftObjects {
                   .setCronSchedule("cron")
                   .setControl(utf8("control"))
                   .setParentClosePolicy(ParentClosePolicy.ABANDON)
-                  .setWorkflowIdReusePolicy(WorkflowIdReusePolicy.AllowDuplicate));
+                  .setWorkflowIdReusePolicy(WorkflowIdReusePolicy.AllowDuplicate)
+                  .setCronOverlapPolicy(CRON_OVERLAP_POLICY)
+                  .setActiveClusterSelectionPolicy(ACTIVE_CLUSTER_SELECTION_POLICY));
   public static Decision DECISION_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION =
       new Decision()
           .setDecisionType(DecisionType.SignalExternalWorkflowExecution)
@@ -883,7 +901,9 @@ public final class ThriftObjects {
           .setHeader(HEADER)
           .setJitterStartSeconds(0)
           .setDelayStartSeconds(3)
-          .setFirstRunAtTimestamp(123456789L);
+          .setFirstRunAtTimestamp(123456789L)
+          .setCronOverlapPolicy(CRON_OVERLAP_POLICY)
+          .setActiveClusterSelectionPolicy(ACTIVE_CLUSTER_SELECTION_POLICY);
   public static final com.uber.cadence.SignalWithStartWorkflowExecutionRequest
       SIGNAL_WITH_START_WORKFLOW_EXECUTION =
           new SignalWithStartWorkflowExecutionRequest()
@@ -907,7 +927,9 @@ public final class ThriftObjects {
               .setHeader(HEADER)
               .setDelayStartSeconds(3)
               .setJitterStartSeconds(0)
-              .setFirstRunAtTimestamp(123456789L);
+              .setFirstRunAtTimestamp(123456789L)
+              .setCronOverlapPolicy(CRON_OVERLAP_POLICY)
+              .setActiveClusterSelectionPolicy(ACTIVE_CLUSTER_SELECTION_POLICY);
 
   public static final StartWorkflowExecutionAsyncRequest START_WORKFLOW_EXECUTION_ASYNC_REQUEST =
       new StartWorkflowExecutionAsyncRequest().setRequest(START_WORKFLOW_EXECUTION);
@@ -1009,7 +1031,8 @@ public final class ThriftObjects {
           .setHistoryArchivalStatus(ArchivalStatus.ENABLED)
           .setHistoryArchivalURI("historyArchivalUri")
           .setVisibilityArchivalStatus(ArchivalStatus.DISABLED)
-          .setVisibilityArchivalURI("visibilityArchivalUri");
+          .setVisibilityArchivalURI("visibilityArchivalUri")
+          .setActiveClusters(ACTIVE_CLUSTERS);
 
   public static final UpdateDomainRequest UPDATE_DOMAIN_REQUEST =
       new UpdateDomainRequest()

--- a/src/test/java/com/uber/cadence/internal/compatibility/proto/DecisionMapperTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/proto/DecisionMapperTest.java
@@ -125,16 +125,10 @@ public class DecisionMapperTest {
           break;
         case ContinueAsNewWorkflowExecution:
           assertMissingFields(
-              decision.continueAsNewWorkflowExecutionDecisionAttributes,
-              "jitterStartSeconds",
-              "activeClusterSelectionPolicy", // aa: not wired yet
-              "cronOverlapPolicy"); // aa: not wired yet
+              decision.continueAsNewWorkflowExecutionDecisionAttributes, "jitterStartSeconds");
           break;
         case StartChildWorkflowExecution:
-          assertMissingFields(
-              decision.startChildWorkflowExecutionDecisionAttributes,
-              "activeClusterSelectionPolicy", // aa: not wired yet
-              "cronOverlapPolicy"); // aa: not wired yet
+          assertNoMissingFields(decision.startChildWorkflowExecutionDecisionAttributes);
           break;
         case SignalExternalWorkflowExecution:
           assertNoMissingFields(decision.signalExternalWorkflowExecutionDecisionAttributes);

--- a/src/test/java/com/uber/cadence/internal/compatibility/proto/RequestMapperTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/proto/RequestMapperTest.java
@@ -165,15 +165,11 @@ public class RequestMapperTest<
         testCase(
             ThriftObjects.START_WORKFLOW_EXECUTION,
             ProtoObjects.START_WORKFLOW_EXECUTION,
-            RequestMapper::startWorkflowExecutionRequest,
-            "activeClusterSelectionPolicy", // aa: not wired yet
-            "cronOverlapPolicy"), // aa: not wired yet
+            RequestMapper::startWorkflowExecutionRequest),
         testCase(
             ThriftObjects.SIGNAL_WITH_START_WORKFLOW_EXECUTION,
             ProtoObjects.SIGNAL_WITH_START_WORKFLOW_EXECUTION,
-            RequestMapper::signalWithStartWorkflowExecutionRequest,
-            "activeClusterSelectionPolicy", // aa: not wired yet
-            "cronOverlapPolicy"), // aa: not wired yet
+            RequestMapper::signalWithStartWorkflowExecutionRequest),
         testCase(
             ThriftObjects.START_WORKFLOW_EXECUTION_ASYNC_REQUEST,
             ProtoObjects.START_WORKFLOW_EXECUTION_ASYNC_REQUEST,
@@ -242,8 +238,7 @@ public class RequestMapperTest<
             ProtoObjects.REGISTER_DOMAIN_REQUEST,
             RequestMapper::registerDomainRequest,
             "emitMetric", // Thrift has this field but proto doens't have it
-            "activeClusters", // aa: not wired yet
-            "activeClustersByRegion"), // aa: not wired yet
+            "activeClustersByRegion"), // thrift-only field, no proto counterpart
         testCase(
             ThriftObjects.UPDATE_DOMAIN_REQUEST,
             ProtoObjects.UPDATE_DOMAIN_REQUEST,


### PR DESCRIPTION
**Stack (2 of 3)** backporting active-active support to v3.13.x — merge after #1090; GitHub retargets this onto `v3.13.x` when #1090 merges:
1. #1090 — IDL bump + adaptation
2. 👉 this PR — aa proto/thrift mappers (#1050 parity)
3. `aa-backport-v3.13.x-wiring` — ActiveClusterSelectionPolicy wiring (backport of #1089)

## What

Ports the active-active mapper additions of #1050 onto v3's split mapper layout (`compatibility/proto` = thrift→proto, `compatibility/thrift` = proto→thrift):

- Type/enum helpers in both directions: `activeClusters`, `clusterAttributeScope`, `activeClusterInfo`, `activeClusterSelectionPolicy`, `clusterAttribute`, `cronOverlapPolicy`
- `RequestMapper`: start / signal-with-start map `cronOverlapPolicy` + `activeClusterSelectionPolicy`; register-domain and update-domain map `activeClusters` (update mask gains `active_clusters`)
- `DecisionMapper`: ContinueAsNew + StartChild decision attributes map both fields
- Beyond #1050: describe/update-domain **responses** also map `activeClusters` back to thrift — required by v3's `Thrift2ProtoAdapter` round-trip tests (which master doesn't have), and it lets v3 users read `ActiveClusters` back from DescribeDomain

Test fixtures updated per #1050; the wired fields are removed from the declared-missing sets in `RequestMapperTest`/`DecisionMapperTest`.

## Testing

Full `./gradlew test` green, `verGJF` clean.