### PR TITLE
feat: complete ActiveClusterSelectionPolicy wiring for start and signal-with-start (backport #1089)

### DIFF
--- a/src/main/java/com/uber/cadence/client/WorkflowOptions.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowOptions.java
@@ -25,6 +25,7 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
 import com.google.common.base.Strings;
+import com.uber.cadence.ActiveClusterSelectionPolicy;
 import com.uber.cadence.WorkflowIdReusePolicy;
 import com.uber.cadence.common.CronSchedule;
 import com.uber.cadence.common.MethodRetry;
@@ -67,6 +68,7 @@ public final class WorkflowOptions {
         .setSearchAttributes(o.getSearchAttributes())
         .setContextPropagators(o.getContextPropagators())
         .setDelayStart(o.delayStart)
+        .setActiveClusterSelectionPolicy(o.activeClusterSelectionPolicy)
         .validateBuildWithDefaults();
   }
 
@@ -94,6 +96,8 @@ public final class WorkflowOptions {
 
     private Duration delayStart;
 
+    private ActiveClusterSelectionPolicy activeClusterSelectionPolicy;
+
     public Builder() {}
 
     public Builder(WorkflowOptions o) {
@@ -111,6 +115,7 @@ public final class WorkflowOptions {
       this.searchAttributes = o.searchAttributes;
       this.contextPropagators = o.contextPropagators;
       this.delayStart = o.delayStart;
+      this.activeClusterSelectionPolicy = o.activeClusterSelectionPolicy;
     }
 
     /**
@@ -223,6 +228,18 @@ public final class WorkflowOptions {
       return this;
     }
 
+    /**
+     * Sets the active cluster selection policy for an active-active domain. The cluster attribute
+     * is a scope/name pair, for example scope {@code "location"} and name {@code "lisbon"}. The
+     * workflow follows that attribute's failover behavior as configured on the domain. This option
+     * is only meaningful for active-active domains.
+     */
+    public Builder setActiveClusterSelectionPolicy(
+        ActiveClusterSelectionPolicy activeClusterSelectionPolicy) {
+      this.activeClusterSelectionPolicy = activeClusterSelectionPolicy;
+      return this;
+    }
+
     public WorkflowOptions build() {
       return new WorkflowOptions(
           workflowId,
@@ -235,7 +252,8 @@ public final class WorkflowOptions {
           memo,
           searchAttributes,
           contextPropagators,
-          delayStart);
+          delayStart,
+          activeClusterSelectionPolicy);
     }
 
     /**
@@ -290,7 +308,8 @@ public final class WorkflowOptions {
           memo,
           searchAttributes,
           contextPropagators,
-          delayStart);
+          delayStart,
+          activeClusterSelectionPolicy);
     }
   }
 
@@ -316,6 +335,8 @@ public final class WorkflowOptions {
 
   private Duration delayStart;
 
+  private ActiveClusterSelectionPolicy activeClusterSelectionPolicy;
+
   private WorkflowOptions(
       String workflowId,
       WorkflowIdReusePolicy workflowIdReusePolicy,
@@ -327,7 +348,8 @@ public final class WorkflowOptions {
       Map<String, Object> memo,
       Map<String, Object> searchAttributes,
       List<ContextPropagator> contextPropagators,
-      Duration delayStart) {
+      Duration delayStart,
+      ActiveClusterSelectionPolicy activeClusterSelectionPolicy) {
     this.workflowId = workflowId;
     this.workflowIdReusePolicy = workflowIdReusePolicy;
     this.executionStartToCloseTimeout = executionStartToCloseTimeout;
@@ -339,6 +361,7 @@ public final class WorkflowOptions {
     this.searchAttributes = searchAttributes;
     this.contextPropagators = contextPropagators;
     this.delayStart = delayStart;
+    this.activeClusterSelectionPolicy = activeClusterSelectionPolicy;
   }
 
   public String getWorkflowId() {
@@ -385,6 +408,10 @@ public final class WorkflowOptions {
     return delayStart;
   }
 
+  public ActiveClusterSelectionPolicy getActiveClusterSelectionPolicy() {
+    return activeClusterSelectionPolicy;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -400,7 +427,8 @@ public final class WorkflowOptions {
         && Objects.equals(memo, that.memo)
         && Objects.equals(searchAttributes, that.searchAttributes)
         && Objects.equals(contextPropagators, that.contextPropagators)
-        && Objects.equals(delayStart, that.delayStart);
+        && Objects.equals(delayStart, that.delayStart)
+        && Objects.equals(activeClusterSelectionPolicy, that.activeClusterSelectionPolicy);
   }
 
   @Override
@@ -416,7 +444,8 @@ public final class WorkflowOptions {
         memo,
         searchAttributes,
         contextPropagators,
-        delayStart);
+        delayStart,
+        activeClusterSelectionPolicy);
   }
 
   @Override
@@ -449,6 +478,9 @@ public final class WorkflowOptions {
         + '\''
         + ", delayStart='"
         + delayStart
+        + '\''
+        + ", activeClusterSelectionPolicy='"
+        + activeClusterSelectionPolicy
         + '\''
         + '}';
   }

--- a/src/main/java/com/uber/cadence/internal/common/StartWorkflowExecutionParameters.java
+++ b/src/main/java/com/uber/cadence/internal/common/StartWorkflowExecutionParameters.java
@@ -17,6 +17,7 @@
 
 package com.uber.cadence.internal.common;
 
+import com.uber.cadence.ActiveClusterSelectionPolicy;
 import com.uber.cadence.WorkflowIdReusePolicy;
 import com.uber.cadence.WorkflowType;
 import com.uber.cadence.client.WorkflowOptions;
@@ -55,6 +56,8 @@ public final class StartWorkflowExecutionParameters {
   private Map<String, byte[]> context;
 
   private Duration delayStart;
+
+  private ActiveClusterSelectionPolicy activeClusterSelectionPolicy;
 
   /**
    * Returns the value of the WorkflowId property for this object.
@@ -317,6 +320,15 @@ public final class StartWorkflowExecutionParameters {
     return delayStart;
   }
 
+  public ActiveClusterSelectionPolicy getActiveClusterSelectionPolicy() {
+    return activeClusterSelectionPolicy;
+  }
+
+  public void setActiveClusterSelectionPolicy(
+      ActiveClusterSelectionPolicy activeClusterSelectionPolicy) {
+    this.activeClusterSelectionPolicy = activeClusterSelectionPolicy;
+  }
+
   public StartWorkflowExecutionParameters withRetryParameters(RetryParameters retryParameters) {
     this.retryParameters = retryParameters;
     return this;
@@ -352,6 +364,7 @@ public final class StartWorkflowExecutionParameters {
     if (options.getCronSchedule() != null) {
       parameters.setCronSchedule(options.getCronSchedule());
     }
+    parameters.setActiveClusterSelectionPolicy(options.getActiveClusterSelectionPolicy());
     return parameters;
   }
 
@@ -396,6 +409,9 @@ public final class StartWorkflowExecutionParameters {
         + ", delayStart='"
         + delayStart
         + '\''
+        + ", activeClusterSelectionPolicy='"
+        + activeClusterSelectionPolicy
+        + '\''
         + '}';
   }
 
@@ -416,7 +432,8 @@ public final class StartWorkflowExecutionParameters {
         && Objects.equals(memo, that.memo)
         && Objects.equals(searchAttributes, that.searchAttributes)
         && Objects.equals(context, that.context)
-        && Objects.equals(delayStart, that.delayStart);
+        && Objects.equals(delayStart, that.delayStart)
+        && Objects.equals(activeClusterSelectionPolicy, that.activeClusterSelectionPolicy);
   }
 
   @Override
@@ -434,7 +451,8 @@ public final class StartWorkflowExecutionParameters {
             memo,
             searchAttributes,
             context,
-            delayStart);
+            delayStart,
+            activeClusterSelectionPolicy);
     result = 31 * result + Arrays.hashCode(input);
     return result;
   }
@@ -456,6 +474,7 @@ public final class StartWorkflowExecutionParameters {
     result.setSearchAttributes(searchAttributes);
     result.setContext(context);
     result.setDelayStart(delayStart);
+    result.setActiveClusterSelectionPolicy(activeClusterSelectionPolicy);
     return result;
   }
 }

--- a/src/main/java/com/uber/cadence/internal/compatibility/thrift/HistoryMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/thrift/HistoryMapper.java
@@ -60,6 +60,7 @@ import static com.uber.cadence.EventType.WorkflowExecutionTimedOut;
 import static com.uber.cadence.internal.compatibility.thrift.EnumMapper.cancelExternalWorkflowExecutionFailedCause;
 import static com.uber.cadence.internal.compatibility.thrift.EnumMapper.childWorkflowExecutionFailedCause;
 import static com.uber.cadence.internal.compatibility.thrift.EnumMapper.continueAsNewInitiator;
+import static com.uber.cadence.internal.compatibility.thrift.EnumMapper.cronOverlapPolicy;
 import static com.uber.cadence.internal.compatibility.thrift.EnumMapper.decisionTaskFailedCause;
 import static com.uber.cadence.internal.compatibility.thrift.EnumMapper.decisionTaskTimedOutCause;
 import static com.uber.cadence.internal.compatibility.thrift.EnumMapper.parentClosePolicy;
@@ -69,6 +70,7 @@ import static com.uber.cadence.internal.compatibility.thrift.EnumMapper.workflow
 import static com.uber.cadence.internal.compatibility.thrift.Helpers.byteStringToArray;
 import static com.uber.cadence.internal.compatibility.thrift.Helpers.durationToSeconds;
 import static com.uber.cadence.internal.compatibility.thrift.Helpers.timeToUnixNano;
+import static com.uber.cadence.internal.compatibility.thrift.TypeMapper.activeClusterSelectionPolicy;
 import static com.uber.cadence.internal.compatibility.thrift.TypeMapper.activityType;
 import static com.uber.cadence.internal.compatibility.thrift.TypeMapper.externalInitiatedId;
 import static com.uber.cadence.internal.compatibility.thrift.TypeMapper.externalWorkflowExecution;
@@ -1147,6 +1149,9 @@ class HistoryMapper {
     res.setSearchAttributes(searchAttributes(t.getSearchAttributes()));
     res.setPrevAutoResetPoints(resetPoints(t.getPrevAutoResetPoints()));
     res.setHeader(header(t.getHeader()));
+    res.setActiveClusterSelectionPolicy(
+        activeClusterSelectionPolicy(t.getActiveClusterSelectionPolicy()));
+    res.setCronOverlapPolicy(cronOverlapPolicy(t.getCronOverlapPolicy()));
     return res;
   }
 

--- a/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternalImpl.java
+++ b/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternalImpl.java
@@ -281,6 +281,9 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     if (startParameters.getDelayStart() != null) {
       request.setDelayStartSeconds((int) startParameters.getDelayStart().getSeconds());
     }
+    if (startParameters.getActiveClusterSelectionPolicy() != null) {
+      request.setActiveClusterSelectionPolicy(startParameters.getActiveClusterSelectionPolicy());
+    }
 
     return request;
   }
@@ -506,6 +509,9 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     }
     if (startParameters.getDelayStart() != null) {
       request.setDelayStartSeconds((int) startParameters.getDelayStart().getSeconds());
+    }
+    if (startParameters.getActiveClusterSelectionPolicy() != null) {
+      request.setActiveClusterSelectionPolicy(startParameters.getActiveClusterSelectionPolicy());
     }
     return request;
   }

--- a/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
@@ -554,6 +554,7 @@ class StateMachines {
     a.setMemo(request.getMemo());
     a.setSearchAttributes((request.getSearchAttributes()));
     a.setHeader(request.getHeader());
+    a.setActiveClusterSelectionPolicy(request.getActiveClusterSelectionPolicy());
     Optional<TestWorkflowMutableState> parent = ctx.getWorkflowMutableState().getParent();
     if (parent.isPresent()) {
       ExecutionId parentExecutionId = parent.get().getExecutionId();

--- a/src/test/java/com/uber/cadence/client/WorkflowOptionsTest.java
+++ b/src/test/java/com/uber/cadence/client/WorkflowOptionsTest.java
@@ -17,6 +17,8 @@
 
 package com.uber.cadence.client;
 
+import com.uber.cadence.ActiveClusterSelectionPolicy;
+import com.uber.cadence.ClusterAttribute;
 import com.uber.cadence.WorkflowIdReusePolicy;
 import com.uber.cadence.common.CronSchedule;
 import com.uber.cadence.common.MethodRetry;
@@ -190,6 +192,73 @@ public class WorkflowOptionsTest {
     }
 
     Assert.fail("invalid cron schedule not caught");
+  }
+
+  private static ActiveClusterSelectionPolicy testPolicy() {
+    return new ActiveClusterSelectionPolicy()
+        .setClusterAttribute(new ClusterAttribute().setScope("location").setName("lisbon"));
+  }
+
+  private static WorkflowOptions.Builder optionsWithPolicy(ActiveClusterSelectionPolicy policy) {
+    return new WorkflowOptions.Builder()
+        .setTaskList("foo")
+        .setExecutionStartToCloseTimeout(Duration.ofSeconds(321))
+        .setActiveClusterSelectionPolicy(policy);
+  }
+
+  @Test
+  public void testActiveClusterSelectionPolicySetOnBuilder() {
+    ActiveClusterSelectionPolicy policy = testPolicy();
+    Assert.assertEquals(
+        policy, optionsWithPolicy(policy).build().getActiveClusterSelectionPolicy());
+  }
+
+  @Test
+  public void testActiveClusterSelectionPolicyDefaultsToNull() {
+    Assert.assertNull(new WorkflowOptions.Builder().build().getActiveClusterSelectionPolicy());
+    Assert.assertNull(
+        optionsWithPolicy(null).validateBuildWithDefaults().getActiveClusterSelectionPolicy());
+  }
+
+  @Test
+  public void testActiveClusterSelectionPolicyKeptByCopyConstructor() {
+    ActiveClusterSelectionPolicy policy = testPolicy();
+    WorkflowOptions o = optionsWithPolicy(policy).build();
+    Assert.assertEquals(
+        policy, new WorkflowOptions.Builder(o).build().getActiveClusterSelectionPolicy());
+  }
+
+  @Test
+  public void testActiveClusterSelectionPolicyKeptByMergeWithAnnotation()
+      throws NoSuchMethodException {
+    ActiveClusterSelectionPolicy policy = testPolicy();
+    WorkflowMethod a =
+        WorkflowOptionsTest.class
+            .getMethod("defaultWorkflowOptions")
+            .getAnnotation(WorkflowMethod.class);
+    Assert.assertEquals(
+        policy,
+        WorkflowOptions.merge(a, null, null, optionsWithPolicy(policy).build())
+            .getActiveClusterSelectionPolicy());
+  }
+
+  @Test
+  public void testActiveClusterSelectionPolicyKeptByMergeWithoutAnnotation() {
+    ActiveClusterSelectionPolicy policy = testPolicy();
+    Assert.assertEquals(
+        policy,
+        WorkflowOptions.merge(null, null, null, optionsWithPolicy(policy).build())
+            .getActiveClusterSelectionPolicy());
+  }
+
+  @Test
+  public void testActiveClusterSelectionPolicyConsideredByEqualsAndHashCode() {
+    WorkflowOptions withPolicy = optionsWithPolicy(testPolicy()).build();
+    WorkflowOptions samePolicy = optionsWithPolicy(testPolicy()).build();
+    WorkflowOptions withoutPolicy = optionsWithPolicy(null).build();
+    Assert.assertEquals(withPolicy, samePolicy);
+    Assert.assertEquals(withPolicy.hashCode(), samePolicy.hashCode());
+    Assert.assertNotEquals(withPolicy, withoutPolicy);
   }
 
   private Map<String, Object> getTestMemo() {

--- a/src/test/java/com/uber/cadence/internal/common/StartWorkflowExecutionParametersTest.java
+++ b/src/test/java/com/uber/cadence/internal/common/StartWorkflowExecutionParametersTest.java
@@ -17,7 +17,11 @@ package com.uber.cadence.internal.common;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.*;
 
+import com.uber.cadence.ActiveClusterSelectionPolicy;
+import com.uber.cadence.ClusterAttribute;
 import com.uber.cadence.WorkflowType;
+import com.uber.cadence.client.WorkflowOptions;
+import java.time.Duration;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -64,7 +68,8 @@ public class StartWorkflowExecutionParametersTest {
             + "maximumAttempts=0, "
             + "nonRetriableErrorReasons=null, expirationIntervalInSeconds=0}, "
             + "cronSchedule='* * * * *', "
-            + "memo='null', searchAttributes='null, context='null, delayStart='null'}";
+            + "memo='null', searchAttributes='null, context='null, delayStart='null', "
+            + "activeClusterSelectionPolicy='null'}";
 
     assertEquals(expectedString, params1.toString());
   }
@@ -124,5 +129,23 @@ public class StartWorkflowExecutionParametersTest {
         params1.getRetryParameters().getExpirationIntervalInSeconds(),
         copy.getRetryParameters().getExpirationIntervalInSeconds());
     assertEquals(params1.getCronSchedule(), copy.getCronSchedule());
+  }
+
+  @Test
+  public void testFromWorkflowOptionsCopiesActiveClusterSelectionPolicy() {
+    ActiveClusterSelectionPolicy policy =
+        new ActiveClusterSelectionPolicy()
+            .setClusterAttribute(new ClusterAttribute().setScope("location").setName("lisbon"));
+    WorkflowOptions options =
+        new WorkflowOptions.Builder()
+            .setTaskList("taskList")
+            .setExecutionStartToCloseTimeout(Duration.ofSeconds(10))
+            .setActiveClusterSelectionPolicy(policy)
+            .build();
+
+    StartWorkflowExecutionParameters parameters =
+        StartWorkflowExecutionParameters.fromWorkflowOptions(options);
+
+    assertEquals(policy, parameters.getActiveClusterSelectionPolicy());
   }
 }

--- a/src/test/java/com/uber/cadence/internal/compatibility/ProtoObjects.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/ProtoObjects.java
@@ -441,6 +441,8 @@ public final class ProtoObjects {
               .setSearchAttributes(SEARCH_ATTRIBUTES)
               .setPrevAutoResetPoints(RESET_POINTS)
               .setHeader(HEADER)
+              .setActiveClusterSelectionPolicy(ACTIVE_CLUSTER_SELECTION_POLICY)
+              .setCronOverlapPolicy(CRON_OVERLAP_POLICY)
               .build();
 
   public static final WorkflowExecutionCompletedEventAttributes

--- a/src/test/java/com/uber/cadence/internal/compatibility/ThriftObjects.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/ThriftObjects.java
@@ -368,7 +368,9 @@ public final class ThriftObjects {
               .setMemo(MEMO)
               .setSearchAttributes(SEARCH_ATTRIBUTES)
               .setPrevAutoResetPoints(RESET_POINTS)
-              .setHeader(HEADER);
+              .setHeader(HEADER)
+              .setActiveClusterSelectionPolicy(ACTIVE_CLUSTER_SELECTION_POLICY)
+              .setCronOverlapPolicy(CRON_OVERLAP_POLICY);
 
   public static final WorkflowExecutionCompletedEventAttributes
       WORKFLOW_EXECUTION_COMPLETED_EVENT_ATTRIBUTES =

--- a/src/test/java/com/uber/cadence/internal/compatibility/thrift/HistoryMapperEventTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/thrift/HistoryMapperEventTest.java
@@ -159,9 +159,7 @@ public class HistoryMapperEventTest<
           ThriftObjects.WORKFLOW_EXECUTION_STARTED_EVENT_ATTRIBUTES,
           "firstScheduledTimeNano",
           "partitionConfig",
-          "requestId",
-          "activeClusterSelectionPolicy", // aa: not wired yet
-          "cronOverlapPolicy"), // aa: not wired yet
+          "requestId"),
       testCase(
           EventType.WorkflowExecutionCompleted,
           ProtoObjects.WORKFLOW_EXECUTION_COMPLETED_EVENT_ATTRIBUTES,

--- a/src/test/java/com/uber/cadence/internal/compatibility/thrift/HistoryMapperTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/thrift/HistoryMapperTest.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.compatibility.thrift;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.uber.cadence.api.v1.ActiveClusterSelectionPolicy;
+import com.uber.cadence.api.v1.ClusterAttribute;
+import com.uber.cadence.api.v1.CronOverlapPolicy;
+import com.uber.cadence.api.v1.WorkflowExecutionStartedEventAttributes;
+import com.uber.cadence.api.v1.WorkflowType;
+import org.junit.Test;
+
+public class HistoryMapperTest {
+
+  @Test
+  public void workflowExecutionStartedEventAttributesMapsActiveClusterSelectionPolicy() {
+    WorkflowExecutionStartedEventAttributes proto =
+        WorkflowExecutionStartedEventAttributes.newBuilder()
+            .setWorkflowType(WorkflowType.newBuilder().setName("wf").build())
+            .setActiveClusterSelectionPolicy(
+                ActiveClusterSelectionPolicy.newBuilder()
+                    .setClusterAttribute(
+                        ClusterAttribute.newBuilder()
+                            .setScope("location")
+                            .setName("lisbon")
+                            .build())
+                    .build())
+            .build();
+
+    com.uber.cadence.WorkflowExecutionStartedEventAttributes result =
+        HistoryMapper.workflowExecutionStartedEventAttributes(proto);
+
+    assertEquals(
+        "location", result.getActiveClusterSelectionPolicy().getClusterAttribute().getScope());
+    assertEquals(
+        "lisbon", result.getActiveClusterSelectionPolicy().getClusterAttribute().getName());
+  }
+
+  @Test
+  public void workflowExecutionStartedEventAttributesMapsCronOverlapPolicy() {
+    WorkflowExecutionStartedEventAttributes proto =
+        WorkflowExecutionStartedEventAttributes.newBuilder()
+            .setWorkflowType(WorkflowType.newBuilder().setName("wf").build())
+            .setCronOverlapPolicy(CronOverlapPolicy.CRON_OVERLAP_POLICY_BUFFER_ONE)
+            .build();
+
+    com.uber.cadence.WorkflowExecutionStartedEventAttributes result =
+        HistoryMapper.workflowExecutionStartedEventAttributes(proto);
+
+    assertEquals(com.uber.cadence.CronOverlapPolicy.BUFFERONE, result.getCronOverlapPolicy());
+  }
+
+  @Test
+  public void workflowExecutionStartedEventAttributesLeavesAbsentFieldsNull() {
+    WorkflowExecutionStartedEventAttributes proto =
+        WorkflowExecutionStartedEventAttributes.newBuilder()
+            .setWorkflowType(WorkflowType.newBuilder().setName("wf").build())
+            .build();
+
+    com.uber.cadence.WorkflowExecutionStartedEventAttributes result =
+        HistoryMapper.workflowExecutionStartedEventAttributes(proto);
+
+    assertNull(result.getActiveClusterSelectionPolicy());
+    assertNull(result.getCronOverlapPolicy());
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/external/GenericWorkflowClientExternalImplTest.java
+++ b/src/test/java/com/uber/cadence/internal/external/GenericWorkflowClientExternalImplTest.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.external;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.uber.cadence.ActiveClusterSelectionPolicy;
+import com.uber.cadence.ClusterAttribute;
+import com.uber.cadence.SignalWithStartWorkflowExecutionRequest;
+import com.uber.cadence.StartWorkflowExecutionRequest;
+import com.uber.cadence.StartWorkflowExecutionResponse;
+import com.uber.cadence.WorkflowType;
+import com.uber.cadence.internal.common.SignalWithStartWorkflowExecutionParameters;
+import com.uber.cadence.internal.common.StartWorkflowExecutionParameters;
+import com.uber.cadence.serviceclient.IWorkflowService;
+import com.uber.m3.tally.NoopScope;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class GenericWorkflowClientExternalImplTest {
+
+  private static final ActiveClusterSelectionPolicy POLICY =
+      new ActiveClusterSelectionPolicy()
+          .setClusterAttribute(new ClusterAttribute().setScope("location").setName("lisbon"));
+
+  private IWorkflowService service;
+  private GenericWorkflowClientExternalImpl client;
+
+  @Before
+  public void setUp() {
+    service = mock(IWorkflowService.class);
+    client = new GenericWorkflowClientExternalImpl(service, "test-domain", new NoopScope());
+  }
+
+  private StartWorkflowExecutionParameters startParameters() {
+    StartWorkflowExecutionParameters parameters = new StartWorkflowExecutionParameters();
+    parameters.setWorkflowId("wid");
+    parameters.setWorkflowType(new WorkflowType().setName("wt"));
+    parameters.setTaskList("tl");
+    parameters.setExecutionStartToCloseTimeoutSeconds(10);
+    parameters.setTaskStartToCloseTimeoutSeconds(10);
+    parameters.setActiveClusterSelectionPolicy(POLICY);
+    return parameters;
+  }
+
+  @Test
+  public void startWorkflowCarriesActiveClusterSelectionPolicy() throws Exception {
+    when(service.StartWorkflowExecution(any()))
+        .thenReturn(new StartWorkflowExecutionResponse().setRunId("rid"));
+
+    client.startWorkflow(startParameters());
+
+    ArgumentCaptor<StartWorkflowExecutionRequest> captor =
+        ArgumentCaptor.forClass(StartWorkflowExecutionRequest.class);
+    verify(service).StartWorkflowExecution(captor.capture());
+    assertEquals(POLICY, captor.getValue().getActiveClusterSelectionPolicy());
+  }
+
+  @Test
+  public void signalWithStartCarriesActiveClusterSelectionPolicy() throws Exception {
+    when(service.SignalWithStartWorkflowExecution(any()))
+        .thenReturn(new com.uber.cadence.StartWorkflowExecutionResponse().setRunId("rid"));
+
+    SignalWithStartWorkflowExecutionParameters parameters =
+        new SignalWithStartWorkflowExecutionParameters(startParameters(), "signal", new byte[] {1});
+    client.signalWithStartWorkflowExecution(parameters);
+
+    ArgumentCaptor<SignalWithStartWorkflowExecutionRequest> captor =
+        ArgumentCaptor.forClass(SignalWithStartWorkflowExecutionRequest.class);
+    verify(service).SignalWithStartWorkflowExecution(captor.capture());
+    assertEquals(POLICY, captor.getValue().getActiveClusterSelectionPolicy());
+  }
+}

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -30,8 +30,10 @@ import static org.junit.Assume.assumeTrue;
 
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.uber.cadence.ActiveClusterSelectionPolicy;
 import com.uber.cadence.BadRequestError;
 import com.uber.cadence.CancellationAlreadyRequestedError;
+import com.uber.cadence.ClusterAttribute;
 import com.uber.cadence.DomainAlreadyExistsError;
 import com.uber.cadence.DomainNotActiveError;
 import com.uber.cadence.EntityNotExistsError;
@@ -1415,6 +1417,29 @@ public class WorkflowTest {
     String memoRetrieved =
         JsonDataConverter.getInstance().fromData(memoBytes, String.class, String.class);
     assertEquals(testMemoValue, memoRetrieved);
+  }
+
+  @Test
+  @RequiresTestService
+  public void testStartWithActiveClusterSelectionPolicy() {
+    ActiveClusterSelectionPolicy policy =
+        new ActiveClusterSelectionPolicy()
+            .setClusterAttribute(new ClusterAttribute().setScope("location").setName("lisbon"));
+
+    startWorkerFor(TestMultiargsWorkflowsImpl.class);
+    WorkflowOptions workflowOptions =
+        newWorkflowOptionsBuilder(taskList).setActiveClusterSelectionPolicy(policy).build();
+    TestMultiargsWorkflowsFunc stubF =
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsFunc.class, workflowOptions);
+    WorkflowExecution executionF = WorkflowClient.start(stubF::func);
+
+    GetWorkflowExecutionHistoryResponse historyResp =
+        WorkflowExecutionUtils.getHistoryPage(
+            new byte[] {}, workflowClient.getService(), DOMAIN, executionF);
+    HistoryEvent startEvent = historyResp.getHistory().getEvents().get(0);
+    assertEquals(
+        policy,
+        startEvent.getWorkflowExecutionStartedEventAttributes().getActiveClusterSelectionPolicy());
   }
 
   @Test


### PR DESCRIPTION
**Stack (3 of 3)** backporting active-active support to v3.13.x — merge last; GitHub retargets this onto the previous base as the stack merges:
1. #1090 — IDL bump + adaptation
2. #1091 — aa proto/thrift mappers (#1050 parity)
3. 👉 this PR — ActiveClusterSelectionPolicy wiring (backport of #1089)

## What

Backport of #1089 (`5187ef64`) from master:

- `WorkflowOptions.setActiveClusterSelectionPolicy` — the policy flows through `StartWorkflowExecutionParameters` and `GenericWorkflowClientExternalImpl` onto start and signal-with-start requests
- `thrift/HistoryMapper` maps `activeClusterSelectionPolicy` and `cronOverlapPolicy` on `WorkflowExecutionStartedEventAttributes` (master's `proto/mappers` hunk adapted to v3's split layout)
- Test service `StateMachines` propagates the policy to the started event

Adaptations vs. master: `HistoryMapperTest` relocated to the thrift mapper package (that's v3's proto→thrift direction); v3's fixture-driven `HistoryMapperEventTest` now sets both fields on the started-event fixtures and their expected-missing declarations are removed. The public API is source-identical to v4: `com.uber.cadence.ActiveClusterSelectionPolicy` (thrift-generated on v3, internal entity on v4).

## Testing

Full `./gradlew test` green, `verGJF` clean. New tests: `HistoryMapperTest` (3 cases), `GenericWorkflowClientExternalImplTest`, plus `WorkflowOptionsTest`/`StartWorkflowExecutionParametersTest`/`WorkflowTest` additions from #1089.