### PR TITLE
fix(worker): propagate local activity queue backpressure on full queue

### DIFF
--- a/src/main/java/com/uber/cadence/internal/worker/LocalActivityPollTask.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocalActivityPollTask.java
@@ -43,9 +43,13 @@ final class LocalActivityPollTask
   @Override
   public Boolean apply(LocalActivityWorker.Task task, Duration maxWaitAllowed) {
     try {
-      pendingTasks.offer(task, maxWaitAllowed.toMillis(), TimeUnit.MILLISECONDS);
-      return true;
+      // offer returns false when the queue is still full after maxWaitAllowed elapses.
+      // Propagate that instead of dropping the task: the caller relies on a false return
+      // to force a new decision task, otherwise the workflow would wait for a local
+      // activity completion that never arrives.
+      return pendingTasks.offer(task, maxWaitAllowed.toMillis(), TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       return false;
     }
   }

--- a/src/test/java/com/uber/cadence/internal/worker/LocalActivityPollTaskTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/LocalActivityPollTaskTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * <p>Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+ * except in compliance with the License. A copy of the License is located at
+ *
+ * <p>http://aws.amazon.com/apache2.0
+ *
+ * <p>or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.uber.cadence.internal.worker;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Duration;
+import org.junit.Test;
+
+public class LocalActivityPollTaskTest {
+
+  // Mirrors the private QUEUE_SIZE in LocalActivityPollTask.
+  private static final int QUEUE_SIZE = 1000;
+
+  private static LocalActivityWorker.Task newTask() {
+    return new LocalActivityWorker.Task(null, null, 0, null, null);
+  }
+
+  @Test
+  public void applyReturnsFalseWhenQueueIsFull() {
+    LocalActivityPollTask poller = new LocalActivityPollTask();
+
+    // Fill the bounded queue to capacity; while there is room each offer succeeds immediately.
+    for (int i = 0; i < QUEUE_SIZE; i++) {
+      assertTrue(poller.apply(newTask(), Duration.ofMillis(10)));
+    }
+
+    // Queue is now full. apply must report failure (not silently drop the task and report
+    // success) so the caller can force a new decision task instead of waiting for a local
+    // activity completion that never arrives. It should also wait up to maxWaitAllowed first.
+    long start = System.currentTimeMillis();
+    assertFalse(poller.apply(newTask(), Duration.ofMillis(50)));
+    long waitedMillis = System.currentTimeMillis() - start;
+    assertTrue("apply should wait up to maxWaitAllowed before giving up", waitedMillis >= 40);
+
+    // Draining a slot frees capacity, so the next offer succeeds again.
+    poller.poll();
+    assertTrue(poller.apply(newTask(), Duration.ofMillis(10)));
+  }
+
+  @Test
+  public void applyReturnsFalseAndRestoresInterruptWhenInterrupted() {
+    LocalActivityPollTask poller = new LocalActivityPollTask();
+
+    // A set interrupt status makes the interruptible offer throw immediately.
+    Thread.currentThread().interrupt();
+    boolean applied = poller.apply(newTask(), Duration.ofMillis(10));
+
+    assertFalse(applied);
+    // Thread.interrupted() returns true only if apply restored the interrupt flag; it also
+    // clears the status so it does not leak into other tests.
+    assertTrue("interrupt status should be restored", Thread.interrupted());
+  }
+}


### PR DESCRIPTION
## What changed
- `LocalActivityPollTask.apply` now returns `BlockingQueue.offer`'s result instead of always `true`, and restores the interrupt flag on `InterruptedException`.

## Why
`apply` discarded `offer`'s boolean, so when the local-activity queue (capacity 1000) is full the task was dropped but reported as accepted. The caller `ClockDecisionContext.startUnstartedLaTasks` has `if (!applied) return false;` a designed backpressure path (force a new decision task) that was therefore dead code. Result: under queue saturation a task is silently lost and the workflow can wait for a local-activity completion that never arrives.

## How tested
- `./gradlew test --tests "com.uber.cadence.internal.worker.LocalActivityPollTaskTest"` (fails without the fix, passes with it).

## Risks
Low. Restores an intended, previously-dead safety path. The changed return value only differs from prior behavior when the queue is actually full, so the common path is unchanged.

## Note
An earlier revision also tweaked `ClockDecisionContext.awaitTaskCompletion` to honor its timeout; that changed local-activity batching semantics (WorkflowTest LA batching/query failures in CI) and was reverted — the block-until-completion behavior there is intentional.